### PR TITLE
audit: APEX-498 - Restrict transfers Nexus<->Vector

### DIFF
--- a/common/chain_id.go
+++ b/common/chain_id.go
@@ -1,5 +1,7 @@
 package common
 
+import "fmt"
+
 type chainIDNum = uint8
 
 const (
@@ -47,4 +49,13 @@ func IsExistingChainID(chainIDStr string) bool {
 
 func IsEVMChainID(chainIDStr string) bool {
 	return chainIDStr == ChainIDStrNexus
+}
+
+func IsTxDirectionAllowed(srcChainID, destChainID string) error {
+	if (srcChainID == ChainIDStrNexus && destChainID == ChainIDStrVector) ||
+		(srcChainID == ChainIDStrVector && destChainID == ChainIDStrNexus) {
+		return fmt.Errorf("transaction direction not allowed: %s -> %s", srcChainID, destChainID)
+	}
+
+	return nil
 }

--- a/oracle_cardano/processor/tx_processors/success/bridging_requested_processor.go
+++ b/oracle_cardano/processor/tx_processors/success/bridging_requested_processor.go
@@ -164,12 +164,12 @@ func (p *BridgingRequestedProcessorImpl) validate(
 		return fmt.Errorf("unsupported chain id found in tx. chain id: %v", tx.OriginChainID)
 	}
 
-	if err := utils.ValidateOutputsHaveTokens(tx, appConfig); err != nil {
+	if err := common.IsTxDirectionAllowed(tx.OriginChainID, metadata.DestinationChainID); err != nil {
 		return err
 	}
 
-	if tx.OriginChainID == common.ChainIDStrVector && metadata.DestinationChainID == common.ChainIDStrNexus {
-		return fmt.Errorf("transaction direction not allowed: %s -> %s", tx.OriginChainID, metadata.DestinationChainID)
+	if err := utils.ValidateOutputsHaveTokens(tx, appConfig); err != nil {
+		return err
 	}
 
 	multisigUtxo, err := utils.ValidateTxOutputs(tx, appConfig, false)

--- a/oracle_cardano/processor/tx_processors/success/bridging_requested_processor.go
+++ b/oracle_cardano/processor/tx_processors/success/bridging_requested_processor.go
@@ -168,6 +168,10 @@ func (p *BridgingRequestedProcessorImpl) validate(
 		return err
 	}
 
+	if tx.OriginChainID == common.ChainIDStrVector && metadata.DestinationChainID == common.ChainIDStrNexus {
+		return fmt.Errorf("transaction direction not allowed: %s -> %s", tx.OriginChainID, metadata.DestinationChainID)
+	}
+
 	multisigUtxo, err := utils.ValidateTxOutputs(tx, appConfig, false)
 	if err != nil {
 		return err

--- a/oracle_eth/processor/tx_processors/success/bridging_requested_processor.go
+++ b/oracle_eth/processor/tx_processors/success/bridging_requested_processor.go
@@ -142,6 +142,10 @@ func (*BridgingRequestedProcessorImpl) addRefundRequestClaim(
 func (p *BridgingRequestedProcessorImpl) validate(
 	tx *core.EthTx, metadata *core.BridgingRequestEthMetadata, appConfig *oCore.AppConfig,
 ) error {
+	if tx.OriginChainID == common.ChainIDStrNexus && metadata.DestinationChainID == common.ChainIDStrVector {
+		return fmt.Errorf("transaction direction not allowed: %s -> %s", tx.OriginChainID, metadata.DestinationChainID)
+	}
+
 	_, ethSrcConfig := oUtils.GetChainConfig(appConfig, tx.OriginChainID)
 	if ethSrcConfig == nil {
 		return fmt.Errorf("origin chain not registered: %v", tx.OriginChainID)

--- a/oracle_eth/processor/tx_processors/success/bridging_requested_processor.go
+++ b/oracle_eth/processor/tx_processors/success/bridging_requested_processor.go
@@ -142,8 +142,8 @@ func (*BridgingRequestedProcessorImpl) addRefundRequestClaim(
 func (p *BridgingRequestedProcessorImpl) validate(
 	tx *core.EthTx, metadata *core.BridgingRequestEthMetadata, appConfig *oCore.AppConfig,
 ) error {
-	if tx.OriginChainID == common.ChainIDStrNexus && metadata.DestinationChainID == common.ChainIDStrVector {
-		return fmt.Errorf("transaction direction not allowed: %s -> %s", tx.OriginChainID, metadata.DestinationChainID)
+	if err := common.IsTxDirectionAllowed(tx.OriginChainID, metadata.DestinationChainID); err != nil {
+		return err
 	}
 
 	_, ethSrcConfig := oUtils.GetChainConfig(appConfig, tx.OriginChainID)

--- a/oracle_eth/processor/tx_processors/success/bridging_requested_processor_test.go
+++ b/oracle_eth/processor/tx_processors/success/bridging_requested_processor_test.go
@@ -128,6 +128,26 @@ func TestBridgingRequestedProcessor(t *testing.T) {
 		require.ErrorContains(t, err, "destination chain not registered")
 	})
 
+	t.Run("ValidateAndAddClaim forbidden transaction direction", func(t *testing.T) {
+		destinationChainNonRegisteredMetadata, err := core.MarshalEthMetadata(core.BridgingRequestEthMetadata{
+			BridgingTxType:     common.BridgingTxTypeBridgingRequest,
+			DestinationChainID: common.ChainIDStrVector,
+			SenderAddr:         "addr1",
+			Transactions:       []core.BridgingRequestEthMetadataTransaction{},
+			FeeAmount:          big.NewInt(0),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, destinationChainNonRegisteredMetadata)
+
+		claims := &oCore.BridgeClaims{}
+		err = proc.ValidateAndAddClaim(claims, &core.EthTx{
+			Metadata:      destinationChainNonRegisteredMetadata,
+			OriginChainID: common.ChainIDStrNexus,
+		}, appConfig)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "transaction direction not allowed")
+	})
+
 	t.Run("ValidateAndAddClaim more than max receivers in metadata", func(t *testing.T) {
 		moreThanMaxReceiversReceiversMetadata, err := core.MarshalEthMetadata(core.BridgingRequestEthMetadata{
 			BridgingTxType:     common.BridgingTxTypeBridgingRequest,


### PR DESCRIPTION
Oracle should validate metadata and forbid Nexus<->Vector transfers