### PR TITLE
AD 584 - RefundEnabled flag logic

### DIFF
--- a/oracle_cardano/core/interfaces.go
+++ b/oracle_cardano/core/interfaces.go
@@ -69,6 +69,9 @@ type CardanoTxSuccessRefundProcessor interface {
 	HandleBridgingProcessorError(
 		claims *cCore.BridgeClaims, tx *CardanoTx, appConfig *cCore.AppConfig,
 		err error, errContext string) error
+
+	HandleBridgingProcessorPreValidate(
+		tx *CardanoTx, appConfig *cCore.AppConfig) error
 }
 
 type CardanoBridgeDataFetcher interface {

--- a/oracle_cardano/core/interfaces.go
+++ b/oracle_cardano/core/interfaces.go
@@ -63,6 +63,14 @@ type CardanoTxFailedProcessor interface {
 	ValidateAndAddClaim(claims *cCore.BridgeClaims, tx *BridgeExpectedCardanoTx, appConfig *cCore.AppConfig) error
 }
 
+type CardanoTxSuccessRefundProcessor interface {
+	CardanoTxSuccessProcessor
+
+	HandleBridgingProcessorError(
+		claims *cCore.BridgeClaims, tx *CardanoTx, appConfig *cCore.AppConfig,
+		err error, errContext string) error
+}
+
 type CardanoBridgeDataFetcher interface {
 	cCore.BridgeDataFetcher
 	FetchLatestBlockPoint(chainID string) (*indexer.BlockPoint, error)

--- a/oracle_cardano/core/test_mocks.go
+++ b/oracle_cardano/core/test_mocks.go
@@ -1,6 +1,8 @@
 package core
 
 import (
+	"fmt"
+
 	"github.com/Ethernal-Tech/apex-bridge/common"
 	"github.com/Ethernal-Tech/apex-bridge/eth"
 	cCore "github.com/Ethernal-Tech/apex-bridge/oracle_common/core"
@@ -272,6 +274,44 @@ func (m *CardanoTxSuccessProcessorMock) ValidateAndAddClaim(
 }
 
 var _ CardanoTxSuccessProcessor = (*CardanoTxSuccessProcessorMock)(nil)
+
+type CardanoTxSuccessRefundProcessorMock struct {
+	mock.Mock
+	SuccessProc *CardanoTxSuccessProcessorMock
+}
+
+// GetType implements CardanoTxSuccessRefundProcessor.
+func (m *CardanoTxSuccessRefundProcessorMock) GetType() common.BridgingTxType {
+	return m.SuccessProc.GetType()
+}
+
+// HandleBridgingProcessorError implements CardanoTxSuccessRefundProcessor.
+func (m *CardanoTxSuccessRefundProcessorMock) HandleBridgingProcessorError(
+	claims *cCore.BridgeClaims, tx *CardanoTx, appConfig *cCore.AppConfig,
+	err error, errContext string,
+) error {
+	if appConfig.RefundEnabled {
+		args := m.Called(claims, tx, appConfig)
+
+		return args.Error(0)
+	}
+
+	return fmt.Errorf("%s. tx: %v, err: %w", errContext, tx, err)
+}
+
+// PreValidate implements CardanoTxSuccessRefundProcessor.
+func (m *CardanoTxSuccessRefundProcessorMock) PreValidate(
+	tx *CardanoTx, appConfig *cCore.AppConfig) error {
+	return m.SuccessProc.PreValidate(tx, appConfig)
+}
+
+// ValidateAndAddClaim implements CardanoTxSuccessRefundProcessor.
+func (m *CardanoTxSuccessRefundProcessorMock) ValidateAndAddClaim(
+	claims *cCore.BridgeClaims, tx *CardanoTx, appConfig *cCore.AppConfig) error {
+	return m.SuccessProc.ValidateAndAddClaim(claims, tx, appConfig)
+}
+
+var _ CardanoTxSuccessRefundProcessor = (*CardanoTxSuccessRefundProcessorMock)(nil)
 
 type CardanoTxFailedProcessorMock struct {
 	mock.Mock

--- a/oracle_cardano/core/test_mocks.go
+++ b/oracle_cardano/core/test_mocks.go
@@ -280,6 +280,14 @@ type CardanoTxSuccessRefundProcessorMock struct {
 	SuccessProc *CardanoTxSuccessProcessorMock
 }
 
+// HandleBridgingProcessorPreValidate implements CardanoTxSuccessRefundProcessor.
+func (m *CardanoTxSuccessRefundProcessorMock) HandleBridgingProcessorPreValidate(
+	tx *CardanoTx, appConfig *cCore.AppConfig) error {
+	args := m.Called(tx, appConfig)
+
+	return args.Error(0)
+}
+
 // GetType implements CardanoTxSuccessRefundProcessor.
 func (m *CardanoTxSuccessRefundProcessorMock) GetType() common.BridgingTxType {
 	return m.SuccessProc.GetType()

--- a/oracle_cardano/processor/tx_processors/success/bridging_requested_processor.go
+++ b/oracle_cardano/processor/tx_processors/success/bridging_requested_processor.go
@@ -134,7 +134,7 @@ func (p *BridgingRequestedProcessorImpl) addBridgingRequestClaim(
 func (p *BridgingRequestedProcessorImpl) validate(
 	tx *core.CardanoTx, metadata *common.BridgingRequestMetadata, appConfig *cCore.AppConfig,
 ) error {
-	if err := p.refundRequestProcessor.PreValidate(tx, appConfig); err != nil {
+	if err := p.refundRequestProcessor.HandleBridgingProcessorPreValidate(tx, appConfig); err != nil {
 		return err
 	}
 

--- a/oracle_cardano/processor/tx_processors/success/bridging_requested_processor.go
+++ b/oracle_cardano/processor/tx_processors/success/bridging_requested_processor.go
@@ -18,12 +18,12 @@ import (
 var _ core.CardanoTxSuccessProcessor = (*BridgingRequestedProcessorImpl)(nil)
 
 type BridgingRequestedProcessorImpl struct {
-	refundRequestProcessor core.CardanoTxSuccessProcessor
+	refundRequestProcessor core.CardanoTxSuccessRefundProcessor
 	logger                 hclog.Logger
 }
 
 func NewBridgingRequestedProcessor(
-	refundRequestProcessor core.CardanoTxSuccessProcessor,
+	refundRequestProcessor core.CardanoTxSuccessRefundProcessor,
 	logger hclog.Logger,
 ) *BridgingRequestedProcessorImpl {
 	return &BridgingRequestedProcessorImpl{
@@ -45,11 +45,13 @@ func (p *BridgingRequestedProcessorImpl) ValidateAndAddClaim(
 ) error {
 	metadata, err := common.UnmarshalMetadata[common.BridgingRequestMetadata](common.MetadataEncodingTypeCbor, tx.Metadata)
 	if err != nil {
-		return p.onError(claims, tx, appConfig, err, "failed to unmarshal metadata")
+		return p.refundRequestProcessor.HandleBridgingProcessorError(
+			claims, tx, appConfig, err, "failed to unmarshal metadata")
 	}
 
 	if metadata.BridgingTxType != p.GetType() {
-		return p.onError(claims, tx, appConfig, nil, "ValidateAndAddClaim called for irrelevant tx")
+		return p.refundRequestProcessor.HandleBridgingProcessorError(
+			claims, tx, appConfig, nil, "ValidateAndAddClaim called for irrelevant tx")
 	}
 
 	p.logger.Debug("Validating relevant tx", "txHash", tx.Hash, "metadata", metadata)
@@ -58,24 +60,11 @@ func (p *BridgingRequestedProcessorImpl) ValidateAndAddClaim(
 	if err == nil {
 		p.addBridgingRequestClaim(claims, tx, metadata, appConfig)
 	} else {
-		return p.onError(claims, tx, appConfig, err, "validation failed for tx")
+		return p.refundRequestProcessor.HandleBridgingProcessorError(
+			claims, tx, appConfig, err, "validation failed for tx")
 	}
 
 	return nil
-}
-
-func (p *BridgingRequestedProcessorImpl) onError(
-	claims *cCore.BridgeClaims, tx *core.CardanoTx, appConfig *cCore.AppConfig,
-	err error, errContext string,
-) error {
-	if appConfig.RefundEnabled {
-		p.logger.Warn(fmt.Sprintf("%s. handing over to refund processor", errContext),
-			"tx", tx, "err", err)
-
-		return p.refundRequestProcessor.ValidateAndAddClaim(claims, tx, appConfig)
-	} else {
-		return fmt.Errorf("%s. tx: %v, err: %w", errContext, tx, err)
-	}
 }
 
 func (p *BridgingRequestedProcessorImpl) addBridgingRequestClaim(
@@ -145,12 +134,8 @@ func (p *BridgingRequestedProcessorImpl) addBridgingRequestClaim(
 func (p *BridgingRequestedProcessorImpl) validate(
 	tx *core.CardanoTx, metadata *common.BridgingRequestMetadata, appConfig *cCore.AppConfig,
 ) error {
-	if appConfig.RefundEnabled && (tx.BatchTryCount > appConfig.TryCountLimits.MaxBatchTryCount ||
-		tx.SubmitTryCount > appConfig.TryCountLimits.MaxSubmitTryCount) {
-		return fmt.Errorf(
-			"try count exceeded. BatchTryCount: (current, max)=(%d, %d), SubmitTryCount: (current, max)=(%d, %d)",
-			tx.BatchTryCount, appConfig.TryCountLimits.MaxBatchTryCount,
-			tx.SubmitTryCount, appConfig.TryCountLimits.MaxSubmitTryCount)
+	if err := p.refundRequestProcessor.PreValidate(tx, appConfig); err != nil {
+		return err
 	}
 
 	chainConfig := appConfig.CardanoChains[tx.OriginChainID]

--- a/oracle_cardano/processor/tx_processors/success/bridging_requested_processor_test.go
+++ b/oracle_cardano/processor/tx_processors/success/bridging_requested_processor_test.go
@@ -56,6 +56,7 @@ func TestBridgingRequestedProcessor(t *testing.T) {
 			MaxReceiversPerBridgingRequest: 3,
 			MaxAmountAllowedToBridge:       maxAmountAllowedToBridge,
 		},
+		RefundEnabled: true,
 	}
 	appConfig.FillOut()
 

--- a/oracle_cardano/processor/tx_processors/success/bridging_requested_processor_test.go
+++ b/oracle_cardano/processor/tx_processors/success/bridging_requested_processor_test.go
@@ -185,6 +185,8 @@ func TestBridgingRequestedProcessor(t *testing.T) {
 		}
 		refundRequestProcessorMock.On(
 			"HandleBridgingProcessorError", claims, cardanoTx, appConfig).Return(nil)
+		refundRequestProcessorMock.On(
+			"HandleBridgingProcessorPreValidate", cardanoTx, appConfig).Return(nil)
 
 		proc := NewBridgingRequestedProcessor(refundRequestProcessorMock, hclog.NewNullLogger())
 
@@ -213,6 +215,8 @@ func TestBridgingRequestedProcessor(t *testing.T) {
 		}
 		refundRequestProcessorMock.On(
 			"HandleBridgingProcessorError", claims, cardanoTx, appConfig).Return(nil)
+		refundRequestProcessorMock.On(
+			"HandleBridgingProcessorPreValidate", cardanoTx, appConfig).Return(nil)
 
 		proc := NewBridgingRequestedProcessor(refundRequestProcessorMock, hclog.NewNullLogger())
 
@@ -253,6 +257,8 @@ func TestBridgingRequestedProcessor(t *testing.T) {
 		}
 		refundRequestProcessorMock.On(
 			"HandleBridgingProcessorError", claims, cardanoTx, appConfig).Return(nil)
+		refundRequestProcessorMock.On(
+			"HandleBridgingProcessorPreValidate", cardanoTx, appConfig).Return(nil)
 
 		proc := NewBridgingRequestedProcessor(refundRequestProcessorMock, hclog.NewNullLogger())
 
@@ -294,6 +300,8 @@ func TestBridgingRequestedProcessor(t *testing.T) {
 		}
 		refundRequestProcessorMock.On(
 			"HandleBridgingProcessorError", claims, cardanoTx, appConfig).Return(nil)
+		refundRequestProcessorMock.On(
+			"HandleBridgingProcessorPreValidate", cardanoTx, appConfig).Return(nil)
 
 		proc := NewBridgingRequestedProcessor(refundRequestProcessorMock, hclog.NewNullLogger())
 
@@ -335,6 +343,8 @@ func TestBridgingRequestedProcessor(t *testing.T) {
 		}
 		refundRequestProcessorMock.On(
 			"HandleBridgingProcessorError", claims, cardanoTx, appConfig).Return(nil)
+		refundRequestProcessorMock.On(
+			"HandleBridgingProcessorPreValidate", cardanoTx, appConfig).Return(nil)
 
 		proc := NewBridgingRequestedProcessor(refundRequestProcessorMock, hclog.NewNullLogger())
 
@@ -374,6 +384,8 @@ func TestBridgingRequestedProcessor(t *testing.T) {
 		}
 		refundRequestProcessorMock.On(
 			"HandleBridgingProcessorError", claims, cardanoTx, appConfig).Return(nil)
+		refundRequestProcessorMock.On(
+			"HandleBridgingProcessorPreValidate", cardanoTx, appConfig).Return(nil)
 
 		proc := NewBridgingRequestedProcessor(refundRequestProcessorMock, hclog.NewNullLogger())
 
@@ -414,6 +426,8 @@ func TestBridgingRequestedProcessor(t *testing.T) {
 		}
 		refundRequestProcessorMock.On(
 			"HandleBridgingProcessorError", claims, cardanoTx, appConfig).Return(nil)
+		refundRequestProcessorMock.On(
+			"HandleBridgingProcessorPreValidate", cardanoTx, appConfig).Return(nil)
 
 		proc := NewBridgingRequestedProcessor(refundRequestProcessorMock, hclog.NewNullLogger())
 
@@ -457,6 +471,8 @@ func TestBridgingRequestedProcessor(t *testing.T) {
 		}
 		refundRequestProcessorMock.On(
 			"HandleBridgingProcessorError", claims, cardanoTx, appConfig).Return(nil)
+		refundRequestProcessorMock.On(
+			"HandleBridgingProcessorPreValidate", cardanoTx, appConfig).Return(nil)
 
 		proc := NewBridgingRequestedProcessor(refundRequestProcessorMock, hclog.NewNullLogger())
 
@@ -498,6 +514,8 @@ func TestBridgingRequestedProcessor(t *testing.T) {
 		}
 		refundRequestProcessorMock.On(
 			"HandleBridgingProcessorError", claims, cardanoTx, appConfig).Return(nil)
+		refundRequestProcessorMock.On(
+			"HandleBridgingProcessorPreValidate", cardanoTx, appConfig).Return(nil)
 
 		proc := NewBridgingRequestedProcessor(refundRequestProcessorMock, hclog.NewNullLogger())
 
@@ -538,6 +556,8 @@ func TestBridgingRequestedProcessor(t *testing.T) {
 		}
 		refundRequestProcessorMock.On(
 			"HandleBridgingProcessorError", claims, cardanoTx, appConfig).Return(nil)
+		refundRequestProcessorMock.On(
+			"HandleBridgingProcessorPreValidate", cardanoTx, appConfig).Return(nil)
 
 		proc := NewBridgingRequestedProcessor(refundRequestProcessorMock, hclog.NewNullLogger())
 
@@ -578,6 +598,8 @@ func TestBridgingRequestedProcessor(t *testing.T) {
 		}
 		refundRequestProcessorMock.On(
 			"HandleBridgingProcessorError", claims, cardanoTx, appConfig).Return(nil)
+		refundRequestProcessorMock.On(
+			"HandleBridgingProcessorPreValidate", cardanoTx, appConfig).Return(nil)
 
 		proc := NewBridgingRequestedProcessor(refundRequestProcessorMock, hclog.NewNullLogger())
 
@@ -621,6 +643,8 @@ func TestBridgingRequestedProcessor(t *testing.T) {
 		}
 		refundRequestProcessorMock.On(
 			"HandleBridgingProcessorError", claims, cardanoTx, appConfig).Return(nil)
+		refundRequestProcessorMock.On(
+			"HandleBridgingProcessorPreValidate", cardanoTx, appConfig).Return(nil)
 
 		proc := NewBridgingRequestedProcessor(refundRequestProcessorMock, hclog.NewNullLogger())
 
@@ -664,6 +688,8 @@ func TestBridgingRequestedProcessor(t *testing.T) {
 		}
 		refundRequestProcessorMock.On(
 			"HandleBridgingProcessorError", claims, cardanoTx, appConfig).Return(nil)
+		refundRequestProcessorMock.On(
+			"HandleBridgingProcessorPreValidate", cardanoTx, appConfig).Return(nil)
 
 		proc := NewBridgingRequestedProcessor(refundRequestProcessorMock, hclog.NewNullLogger())
 
@@ -705,6 +731,8 @@ func TestBridgingRequestedProcessor(t *testing.T) {
 		}
 		refundRequestProcessorMock.On(
 			"HandleBridgingProcessorError", claims, cardanoTx, appConfig).Return(nil)
+		refundRequestProcessorMock.On(
+			"HandleBridgingProcessorPreValidate", cardanoTx, appConfig).Return(nil)
 
 		proc := NewBridgingRequestedProcessor(refundRequestProcessorMock, hclog.NewNullLogger())
 
@@ -746,6 +774,8 @@ func TestBridgingRequestedProcessor(t *testing.T) {
 		}
 		refundRequestProcessorMock.On(
 			"HandleBridgingProcessorError", claims, cardanoTx, appConfig).Return(nil)
+		refundRequestProcessorMock.On(
+			"HandleBridgingProcessorPreValidate", cardanoTx, appConfig).Return(nil)
 
 		proc := NewBridgingRequestedProcessor(refundRequestProcessorMock, hclog.NewNullLogger())
 
@@ -786,6 +816,8 @@ func TestBridgingRequestedProcessor(t *testing.T) {
 		}
 		refundRequestProcessorMock.On(
 			"HandleBridgingProcessorError", claims, cardanoTx, appConfig).Return(nil)
+		refundRequestProcessorMock.On(
+			"HandleBridgingProcessorPreValidate", cardanoTx, appConfig).Return(nil)
 
 		proc := NewBridgingRequestedProcessor(refundRequestProcessorMock, hclog.NewNullLogger())
 
@@ -833,6 +865,8 @@ func TestBridgingRequestedProcessor(t *testing.T) {
 		}
 		refundRequestProcessorMock.On(
 			"HandleBridgingProcessorError", claims, cardanoTx, appConfig).Return(nil)
+		refundRequestProcessorMock.On(
+			"HandleBridgingProcessorPreValidate", cardanoTx, appConfig).Return(nil)
 
 		proc := NewBridgingRequestedProcessor(refundRequestProcessorMock, hclog.NewNullLogger())
 
@@ -860,24 +894,30 @@ func TestBridgingRequestedProcessor(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, validMetadata)
 
-		appConfig := getAppConfig(false)
-		refundRequestProcessorMock := &core.CardanoTxSuccessRefundProcessorMock{
-			SuccessProc: &core.CardanoTxSuccessProcessorMock{},
-		}
-		proc := NewBridgingRequestedProcessor(refundRequestProcessorMock, hclog.NewNullLogger())
-
 		claims := &cCore.BridgeClaims{}
 		txOutputs := []*indexer.TxOutput{
 			{Address: primeBridgingAddr, Amount: minFeeForBridging + utxoMinValue},
 		}
-		err = proc.ValidateAndAddClaim(claims, &core.CardanoTx{
+
+		cardanoTx := &core.CardanoTx{
 			Tx: indexer.Tx{
 				Hash:     txHash,
 				Metadata: validMetadata,
 				Outputs:  txOutputs,
 			},
 			OriginChainID: common.ChainIDStrPrime,
-		}, appConfig)
+		}
+
+		appConfig := getAppConfig(false)
+		refundRequestProcessorMock := &core.CardanoTxSuccessRefundProcessorMock{
+			SuccessProc: &core.CardanoTxSuccessProcessorMock{},
+		}
+		refundRequestProcessorMock.On(
+			"HandleBridgingProcessorPreValidate", cardanoTx, appConfig).Return(nil)
+
+		proc := NewBridgingRequestedProcessor(refundRequestProcessorMock, hclog.NewNullLogger())
+
+		err = proc.ValidateAndAddClaim(claims, cardanoTx, appConfig)
 		require.NoError(t, err)
 		require.True(t, claims.Count() == 1)
 		require.Len(t, claims.BridgingRequestClaims, 1)

--- a/oracle_cardano/processor/tx_processors/success/refund_disabled_processor.go
+++ b/oracle_cardano/processor/tx_processors/success/refund_disabled_processor.go
@@ -1,0 +1,38 @@
+package successtxprocessors
+
+import (
+	"fmt"
+
+	"github.com/Ethernal-Tech/apex-bridge/common"
+	"github.com/Ethernal-Tech/apex-bridge/oracle_cardano/core"
+	cCore "github.com/Ethernal-Tech/apex-bridge/oracle_common/core"
+)
+
+var _ core.CardanoTxSuccessRefundProcessor = (*RefundDisabledProcessorImpl)(nil)
+
+type RefundDisabledProcessorImpl struct{}
+
+func NewRefundDisabledProcessor() *RefundDisabledProcessorImpl {
+	return &RefundDisabledProcessorImpl{}
+}
+
+func (*RefundDisabledProcessorImpl) GetType() common.BridgingTxType {
+	return common.TxTypeRefundRequest
+}
+
+func (*RefundDisabledProcessorImpl) PreValidate(tx *core.CardanoTx, appConfig *cCore.AppConfig) error {
+	return nil
+}
+
+func (p *RefundDisabledProcessorImpl) HandleBridgingProcessorError(
+	claims *cCore.BridgeClaims, tx *core.CardanoTx, appConfig *cCore.AppConfig,
+	err error, errContext string,
+) error {
+	return fmt.Errorf("%s. tx: %v, err: %w", errContext, tx, err)
+}
+
+func (p *RefundDisabledProcessorImpl) ValidateAndAddClaim(
+	claims *cCore.BridgeClaims, tx *core.CardanoTx, appConfig *cCore.AppConfig,
+) error {
+	return fmt.Errorf("refund is not enabled")
+}

--- a/oracle_cardano/processor/tx_processors/success/refund_disabled_processor.go
+++ b/oracle_cardano/processor/tx_processors/success/refund_disabled_processor.go
@@ -24,6 +24,11 @@ func (*RefundDisabledProcessorImpl) PreValidate(tx *core.CardanoTx, appConfig *c
 	return nil
 }
 
+func (*RefundDisabledProcessorImpl) HandleBridgingProcessorPreValidate(
+	tx *core.CardanoTx, appConfig *cCore.AppConfig) error {
+	return nil
+}
+
 func (p *RefundDisabledProcessorImpl) HandleBridgingProcessorError(
 	claims *cCore.BridgeClaims, tx *core.CardanoTx, appConfig *cCore.AppConfig,
 	err error, errContext string,

--- a/oracle_cardano/processor/tx_processors/success/refund_request_processor.go
+++ b/oracle_cardano/processor/tx_processors/success/refund_request_processor.go
@@ -45,6 +45,10 @@ func (*RefundRequestProcessorImpl) PreValidate(tx *core.CardanoTx, appConfig *cC
 func (p *RefundRequestProcessorImpl) ValidateAndAddClaim(
 	claims *cCore.BridgeClaims, tx *core.CardanoTx, appConfig *cCore.AppConfig,
 ) error {
+	if !appConfig.RefundEnabled {
+		return fmt.Errorf("refund is not enabled")
+	}
+
 	metadata, err := common.UnmarshalMetadata[common.RefundBridgingRequestMetadata](
 		common.MetadataEncodingTypeCbor, tx.Metadata)
 	if err != nil {

--- a/oracle_cardano/processor/tx_processors/success/refund_request_processor.go
+++ b/oracle_cardano/processor/tx_processors/success/refund_request_processor.go
@@ -39,6 +39,11 @@ func (*RefundRequestProcessorImpl) GetType() common.BridgingTxType {
 }
 
 func (*RefundRequestProcessorImpl) PreValidate(tx *core.CardanoTx, appConfig *cCore.AppConfig) error {
+	return nil
+}
+
+func (*RefundRequestProcessorImpl) HandleBridgingProcessorPreValidate(
+	tx *core.CardanoTx, appConfig *cCore.AppConfig) error {
 	if tx.BatchTryCount > appConfig.TryCountLimits.MaxBatchTryCount ||
 		tx.SubmitTryCount > appConfig.TryCountLimits.MaxSubmitTryCount {
 		return fmt.Errorf(

--- a/oracle_cardano/processor/tx_processors/success/refund_request_processor.go
+++ b/oracle_cardano/processor/tx_processors/success/refund_request_processor.go
@@ -18,7 +18,7 @@ const (
 	unknownNativeTokensUtxoCntMax = 3
 )
 
-var _ core.CardanoTxSuccessProcessor = (*BridgingRequestedProcessorImpl)(nil)
+var _ core.CardanoTxSuccessRefundProcessor = (*RefundRequestProcessorImpl)(nil)
 
 type RefundRequestProcessorImpl struct {
 	logger     hclog.Logger
@@ -39,16 +39,30 @@ func (*RefundRequestProcessorImpl) GetType() common.BridgingTxType {
 }
 
 func (*RefundRequestProcessorImpl) PreValidate(tx *core.CardanoTx, appConfig *cCore.AppConfig) error {
+	if tx.BatchTryCount > appConfig.TryCountLimits.MaxBatchTryCount ||
+		tx.SubmitTryCount > appConfig.TryCountLimits.MaxSubmitTryCount {
+		return fmt.Errorf(
+			"try count exceeded. BatchTryCount: (current, max)=(%d, %d), SubmitTryCount: (current, max)=(%d, %d)",
+			tx.BatchTryCount, appConfig.TryCountLimits.MaxBatchTryCount,
+			tx.SubmitTryCount, appConfig.TryCountLimits.MaxSubmitTryCount)
+	}
+
 	return nil
+}
+
+func (p *RefundRequestProcessorImpl) HandleBridgingProcessorError(
+	claims *cCore.BridgeClaims, tx *core.CardanoTx, appConfig *cCore.AppConfig,
+	err error, errContext string,
+) error {
+	p.logger.Warn(fmt.Sprintf("%s. handing over to refund processor", errContext),
+		"tx", tx, "err", err)
+
+	return p.ValidateAndAddClaim(claims, tx, appConfig)
 }
 
 func (p *RefundRequestProcessorImpl) ValidateAndAddClaim(
 	claims *cCore.BridgeClaims, tx *core.CardanoTx, appConfig *cCore.AppConfig,
 ) error {
-	if !appConfig.RefundEnabled {
-		return fmt.Errorf("refund is not enabled")
-	}
-
 	metadata, err := common.UnmarshalMetadata[common.RefundBridgingRequestMetadata](
 		common.MetadataEncodingTypeCbor, tx.Metadata)
 	if err != nil {

--- a/oracle_cardano/processor/tx_processors/success/refund_request_processor_test.go
+++ b/oracle_cardano/processor/tx_processors/success/refund_request_processor_test.go
@@ -60,6 +60,7 @@ func TestRefundRequestedProcessor(t *testing.T) {
 			MaxReceiversPerBridgingRequest: 3,
 			MaxAmountAllowedToBridge:       maxAmountAllowedToBridge,
 		},
+		RefundEnabled: true,
 	}
 	appConfig.FillOut()
 

--- a/oracle_cardano/processor/tx_processors/success/refund_request_processor_test.go
+++ b/oracle_cardano/processor/tx_processors/success/refund_request_processor_test.go
@@ -87,10 +87,10 @@ func TestRefundRequestedProcessor(t *testing.T) {
 	proc := NewRefundRequestProcessor(hclog.NewNullLogger(), getChainInfos())
 	disabledProc := NewRefundDisabledProcessor()
 
-	t.Run("Refund disabled - PreValidate", func(t *testing.T) {
+	t.Run("Refund disabled - HandleBridgingProcessorPreValidate", func(t *testing.T) {
 		appConfig := getAppConfig(false)
 
-		err := disabledProc.PreValidate(&core.CardanoTx{}, appConfig)
+		err := disabledProc.HandleBridgingProcessorPreValidate(&core.CardanoTx{}, appConfig)
 		require.NoError(t, err)
 	})
 
@@ -111,25 +111,25 @@ func TestRefundRequestedProcessor(t *testing.T) {
 		require.ErrorContains(t, err, "refund is not enabled")
 	})
 
-	t.Run("PreValidate - empty tx", func(t *testing.T) {
+	t.Run("HandleBridgingProcessorPreValidate - empty tx", func(t *testing.T) {
 		appConfig := getAppConfig(false)
 
-		err := proc.PreValidate(&core.CardanoTx{}, appConfig)
+		err := proc.HandleBridgingProcessorPreValidate(&core.CardanoTx{}, appConfig)
 		require.NoError(t, err)
 	})
 
-	t.Run("PreValidate - batchTryCount over", func(t *testing.T) {
+	t.Run("HandleBridgingProcessorPreValidate - batchTryCount over", func(t *testing.T) {
 		appConfig := getAppConfig(false)
 
-		err := proc.PreValidate(&core.CardanoTx{BatchTryCount: 1}, appConfig)
+		err := proc.HandleBridgingProcessorPreValidate(&core.CardanoTx{BatchTryCount: 1}, appConfig)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "try count exceeded")
 	})
 
-	t.Run("PreValidate - submitTryCount over", func(t *testing.T) {
+	t.Run("HandleBridgingProcessorPreValidate - submitTryCount over", func(t *testing.T) {
 		appConfig := getAppConfig(false)
 
-		err := proc.PreValidate(&core.CardanoTx{SubmitTryCount: 1}, appConfig)
+		err := proc.HandleBridgingProcessorPreValidate(&core.CardanoTx{SubmitTryCount: 1}, appConfig)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "try count exceeded")
 	})

--- a/oracle_cardano/processor/txs_processor/data.go
+++ b/oracle_cardano/processor/txs_processor/data.go
@@ -58,9 +58,17 @@ func (pc *txProcessorsCollection) getSuccess(tx *core.CardanoTx, appConfig *cCor
 			return nil, err
 		}
 
+		if !appConfig.RefundEnabled && metadata.BridgingTxType == common.TxTypeRefundRequest {
+			return nil, fmt.Errorf("irrelevant tx. Tx type: %s", metadata.BridgingTxType)
+		}
+
 		txProcessor, relevant = pc.successTxProcessors[string(metadata.BridgingTxType)]
 		if !relevant {
-			txProcessor = pc.successTxProcessors[string(common.TxTypeRefundRequest)]
+			if appConfig.RefundEnabled {
+				txProcessor = pc.successTxProcessors[string(common.TxTypeRefundRequest)]
+			} else {
+				return nil, fmt.Errorf("irrelevant tx. Tx type: %s", metadata.BridgingTxType)
+			}
 		}
 	} else {
 		txProcessor = pc.successTxProcessors[string(common.TxTypeHotWalletFund)]

--- a/oracle_cardano/processor/txs_processor/data.go
+++ b/oracle_cardano/processor/txs_processor/data.go
@@ -58,15 +58,10 @@ func (pc *txProcessorsCollection) getSuccess(tx *core.CardanoTx, appConfig *cCor
 			return nil, err
 		}
 
-		if !appConfig.RefundEnabled && metadata.BridgingTxType == common.TxTypeRefundRequest {
-			return nil, fmt.Errorf("irrelevant tx. Tx type: %s", metadata.BridgingTxType)
-		}
-
 		txProcessor, relevant = pc.successTxProcessors[string(metadata.BridgingTxType)]
 		if !relevant {
-			if appConfig.RefundEnabled {
-				txProcessor = pc.successTxProcessors[string(common.TxTypeRefundRequest)]
-			} else {
+			txProcessor, relevant = pc.successTxProcessors[string(common.TxTypeRefundRequest)]
+			if !relevant {
 				return nil, fmt.Errorf("irrelevant tx. Tx type: %s", metadata.BridgingTxType)
 			}
 		}

--- a/oracle_eth/core/interfaces.go
+++ b/oracle_eth/core/interfaces.go
@@ -56,6 +56,14 @@ type EthTxFailedProcessor interface {
 	ValidateAndAddClaim(claims *oCore.BridgeClaims, tx *BridgeExpectedEthTx, appConfig *oCore.AppConfig) error
 }
 
+type EthTxSuccessRefundProcessor interface {
+	EthTxSuccessProcessor
+
+	HandleBridgingProcessorError(
+		claims *oCore.BridgeClaims, tx *EthTx, appConfig *oCore.AppConfig,
+		err error, errContext string) error
+}
+
 type EthChainObserver interface {
 	Start() error
 	Dispose() error

--- a/oracle_eth/core/interfaces.go
+++ b/oracle_eth/core/interfaces.go
@@ -62,6 +62,9 @@ type EthTxSuccessRefundProcessor interface {
 	HandleBridgingProcessorError(
 		claims *oCore.BridgeClaims, tx *EthTx, appConfig *oCore.AppConfig,
 		err error, errContext string) error
+
+	HandleBridgingProcessorPreValidate(
+		tx *EthTx, appConfig *oCore.AppConfig) error
 }
 
 type EthChainObserver interface {

--- a/oracle_eth/core/test_mocks.go
+++ b/oracle_eth/core/test_mocks.go
@@ -1,6 +1,8 @@
 package core
 
 import (
+	"fmt"
+
 	"github.com/Ethernal-Tech/apex-bridge/common"
 	"github.com/Ethernal-Tech/apex-bridge/eth"
 	oCore "github.com/Ethernal-Tech/apex-bridge/oracle_common/core"
@@ -228,6 +230,42 @@ func (m *EthTxSuccessProcessorMock) ValidateAndAddClaim(
 }
 
 var _ EthTxSuccessProcessor = (*EthTxSuccessProcessorMock)(nil)
+
+type EthTxSuccessRefundProcessorMock struct {
+	mock.Mock
+	SuccessProc EthTxSuccessProcessorMock
+}
+
+// GetType implements EthTxSuccessRefundProcessor.
+func (m *EthTxSuccessRefundProcessorMock) GetType() common.BridgingTxType {
+	return m.SuccessProc.GetType()
+}
+
+// HandleBridgingProcessorError implements EthTxSuccessRefundProcessor.
+func (m *EthTxSuccessRefundProcessorMock) HandleBridgingProcessorError(
+	claims *oCore.BridgeClaims, tx *EthTx, appConfig *oCore.AppConfig,
+	err error, errContext string) error {
+	if appConfig.RefundEnabled {
+		args := m.Called(claims, tx, appConfig)
+
+		return args.Error(0)
+	}
+
+	return fmt.Errorf("%s. tx: %v, err: %w", errContext, tx, err)
+}
+
+// PreValidate implements EthTxSuccessRefundProcessor.
+func (m *EthTxSuccessRefundProcessorMock) PreValidate(tx *EthTx, appConfig *oCore.AppConfig) error {
+	return m.SuccessProc.PreValidate(tx, appConfig)
+}
+
+// ValidateAndAddClaim implements EthTxSuccessRefundProcessor.
+func (m *EthTxSuccessRefundProcessorMock) ValidateAndAddClaim(
+	claims *oCore.BridgeClaims, tx *EthTx, appConfig *oCore.AppConfig) error {
+	return m.SuccessProc.ValidateAndAddClaim(claims, tx, appConfig)
+}
+
+var _ EthTxSuccessRefundProcessor = (*EthTxSuccessRefundProcessorMock)(nil)
 
 type EthTxFailedProcessorMock struct {
 	mock.Mock

--- a/oracle_eth/core/test_mocks.go
+++ b/oracle_eth/core/test_mocks.go
@@ -236,6 +236,14 @@ type EthTxSuccessRefundProcessorMock struct {
 	SuccessProc EthTxSuccessProcessorMock
 }
 
+// HandleBridgingProcessorPreValidate implements EthTxSuccessRefundProcessor.
+func (m *EthTxSuccessRefundProcessorMock) HandleBridgingProcessorPreValidate(
+	tx *EthTx, appConfig *oCore.AppConfig) error {
+	args := m.Called(tx, appConfig)
+
+	return args.Error(0)
+}
+
 // GetType implements EthTxSuccessRefundProcessor.
 func (m *EthTxSuccessRefundProcessorMock) GetType() common.BridgingTxType {
 	return m.SuccessProc.GetType()

--- a/oracle_eth/processor/tx_processors/success/bridging_requested_processor.go
+++ b/oracle_eth/processor/tx_processors/success/bridging_requested_processor.go
@@ -116,7 +116,7 @@ func (p *BridgingRequestedProcessorImpl) addBridgingRequestClaim(
 func (p *BridgingRequestedProcessorImpl) validate(
 	tx *core.EthTx, metadata *core.BridgingRequestEthMetadata, appConfig *oCore.AppConfig,
 ) error {
-	if err := p.refundRequestProcessor.PreValidate(tx, appConfig); err != nil {
+	if err := p.refundRequestProcessor.HandleBridgingProcessorPreValidate(tx, appConfig); err != nil {
 		return err
 	}
 

--- a/oracle_eth/processor/tx_processors/success/bridging_requested_processor_test.go
+++ b/oracle_eth/processor/tx_processors/success/bridging_requested_processor_test.go
@@ -51,6 +51,7 @@ func TestBridgingRequestedProcessor(t *testing.T) {
 			MaxReceiversPerBridgingRequest: 3,
 			MaxAmountAllowedToBridge:       maxAmountAllowedToBridge,
 		},
+		RefundEnabled: true,
 	}
 	appConfig.FillOut()
 

--- a/oracle_eth/processor/tx_processors/success/bridging_requested_processor_test.go
+++ b/oracle_eth/processor/tx_processors/success/bridging_requested_processor_test.go
@@ -61,7 +61,10 @@ func TestBridgingRequestedProcessor(t *testing.T) {
 		claims := &oCore.BridgeClaims{}
 
 		appConfig := getAppConfig(false)
-		refundRequestProcessorMock := &core.EthTxSuccessProcessorMock{}
+		refundRequestProcessorMock := &core.EthTxSuccessRefundProcessorMock{}
+		refundRequestProcessorMock.On(
+			"HandleBridgingProcessorError", claims, &core.EthTx{}, appConfig).Return(nil)
+
 		proc := NewEthBridgingRequestedProcessor(refundRequestProcessorMock, hclog.NewNullLogger())
 
 		err := proc.ValidateAndAddClaim(claims, &core.EthTx{}, appConfig)
@@ -73,10 +76,11 @@ func TestBridgingRequestedProcessor(t *testing.T) {
 		claims := &oCore.BridgeClaims{}
 
 		appConfig := getAppConfig(true)
-		refundRequestProcessorMock := &core.EthTxSuccessProcessorMock{}
-		proc := NewEthBridgingRequestedProcessor(refundRequestProcessorMock, hclog.NewNullLogger())
+		refundRequestProcessorMock := &core.EthTxSuccessRefundProcessorMock{}
+		refundRequestProcessorMock.On(
+			"HandleBridgingProcessorError", claims, &core.EthTx{}, appConfig).Return(nil)
 
-		refundRequestProcessorMock.On("ValidateAndAddClaim", claims, &core.EthTx{}, appConfig).Return(nil)
+		proc := NewEthBridgingRequestedProcessor(refundRequestProcessorMock, hclog.NewNullLogger())
 
 		err := proc.ValidateAndAddClaim(claims, &core.EthTx{}, appConfig)
 		require.NoError(t, err)
@@ -86,12 +90,11 @@ func TestBridgingRequestedProcessor(t *testing.T) {
 		claims := &oCore.BridgeClaims{}
 
 		appConfig := getAppConfig(true)
-		refundRequestProcessorMock := &core.EthTxSuccessProcessorMock{}
-		proc := NewEthBridgingRequestedProcessor(refundRequestProcessorMock, hclog.NewNullLogger())
-
+		refundRequestProcessorMock := &core.EthTxSuccessRefundProcessorMock{}
 		refundRequestProcessorMock.On(
-			"ValidateAndAddClaim", claims, &core.EthTx{}, appConfig).Return(
-			fmt.Errorf("test err"))
+			"HandleBridgingProcessorError", claims, &core.EthTx{}, appConfig).Return(fmt.Errorf("test err"))
+
+		proc := NewEthBridgingRequestedProcessor(refundRequestProcessorMock, hclog.NewNullLogger())
 
 		err := proc.ValidateAndAddClaim(claims, &core.EthTx{}, appConfig)
 		require.Error(t, err)
@@ -108,7 +111,10 @@ func TestBridgingRequestedProcessor(t *testing.T) {
 		claims := &oCore.BridgeClaims{}
 
 		appConfig := getAppConfig(false)
-		refundRequestProcessorMock := &core.EthTxSuccessProcessorMock{}
+		refundRequestProcessorMock := &core.EthTxSuccessRefundProcessorMock{}
+		refundRequestProcessorMock.On(
+			"HandleBridgingProcessorError", claims, &core.EthTx{}, appConfig).Return(nil)
+
 		proc := NewEthBridgingRequestedProcessor(refundRequestProcessorMock, hclog.NewNullLogger())
 
 		err = proc.ValidateAndAddClaim(claims, &core.EthTx{
@@ -126,18 +132,18 @@ func TestBridgingRequestedProcessor(t *testing.T) {
 		require.NotNil(t, irrelevantMetadata)
 
 		claims := &oCore.BridgeClaims{}
+		ethTx := &core.EthTx{
+			Metadata: irrelevantMetadata,
+		}
 
 		appConfig := getAppConfig(true)
-		refundRequestProcessorMock := &core.EthTxSuccessProcessorMock{}
+		refundRequestProcessorMock := &core.EthTxSuccessRefundProcessorMock{}
+		refundRequestProcessorMock.On(
+			"HandleBridgingProcessorError", claims, ethTx, appConfig).Return(nil)
+
 		proc := NewEthBridgingRequestedProcessor(refundRequestProcessorMock, hclog.NewNullLogger())
 
-		refundRequestProcessorMock.On("ValidateAndAddClaim", claims, &core.EthTx{
-			Metadata: irrelevantMetadata,
-		}, appConfig).Return(nil)
-
-		err = proc.ValidateAndAddClaim(claims, &core.EthTx{
-			Metadata: irrelevantMetadata,
-		}, appConfig)
+		err = proc.ValidateAndAddClaim(claims, ethTx, appConfig)
 		require.NoError(t, err)
 	})
 
@@ -149,14 +155,18 @@ func TestBridgingRequestedProcessor(t *testing.T) {
 		require.NotNil(t, relevantButNotFullMetadata)
 
 		claims := &oCore.BridgeClaims{}
+		ethTx := &core.EthTx{
+			Metadata: relevantButNotFullMetadata,
+		}
 
 		appConfig := getAppConfig(false)
-		refundRequestProcessorMock := &core.EthTxSuccessProcessorMock{}
+		refundRequestProcessorMock := &core.EthTxSuccessRefundProcessorMock{}
+		refundRequestProcessorMock.On(
+			"HandleBridgingProcessorError", claims, ethTx, appConfig).Return(nil)
+
 		proc := NewEthBridgingRequestedProcessor(refundRequestProcessorMock, hclog.NewNullLogger())
 
-		err = proc.ValidateAndAddClaim(claims, &core.EthTx{
-			Metadata: relevantButNotFullMetadata,
-		}, appConfig)
+		err = proc.ValidateAndAddClaim(claims, ethTx, appConfig)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "origin chain not registered")
 	})
@@ -169,18 +179,18 @@ func TestBridgingRequestedProcessor(t *testing.T) {
 		require.NotNil(t, relevantButNotFullMetadata)
 
 		claims := &oCore.BridgeClaims{}
+		ethTx := &core.EthTx{
+			Metadata: relevantButNotFullMetadata,
+		}
 
 		appConfig := getAppConfig(true)
-		refundRequestProcessorMock := &core.EthTxSuccessProcessorMock{}
+		refundRequestProcessorMock := &core.EthTxSuccessRefundProcessorMock{}
+		refundRequestProcessorMock.On(
+			"HandleBridgingProcessorError", claims, ethTx, appConfig).Return(nil)
+
 		proc := NewEthBridgingRequestedProcessor(refundRequestProcessorMock, hclog.NewNullLogger())
 
-		refundRequestProcessorMock.On("ValidateAndAddClaim", claims, &core.EthTx{
-			Metadata: relevantButNotFullMetadata,
-		}, appConfig).Return(nil)
-
-		err = proc.ValidateAndAddClaim(claims, &core.EthTx{
-			Metadata: relevantButNotFullMetadata,
-		}, appConfig)
+		err = proc.ValidateAndAddClaim(claims, ethTx, appConfig)
 		require.NoError(t, err)
 	})
 
@@ -196,14 +206,19 @@ func TestBridgingRequestedProcessor(t *testing.T) {
 		require.NotNil(t, metadata)
 
 		claims := &oCore.BridgeClaims{}
-
-		appConfig := getAppConfig(false)
-		proc := NewEthBridgingRequestedProcessor(&core.EthTxSuccessProcessorMock{}, hclog.NewNullLogger())
-
-		err = proc.ValidateAndAddClaim(claims, &core.EthTx{
+		ethTx := &core.EthTx{
 			Metadata:      metadata,
 			OriginChainID: common.ChainIDStrPrime,
-		}, appConfig)
+		}
+
+		appConfig := getAppConfig(false)
+		refundRequestProcessorMock := &core.EthTxSuccessRefundProcessorMock{}
+		refundRequestProcessorMock.On(
+			"HandleBridgingProcessorError", claims, ethTx, appConfig).Return(nil)
+
+		proc := NewEthBridgingRequestedProcessor(refundRequestProcessorMock, hclog.NewNullLogger())
+
+		err = proc.ValidateAndAddClaim(claims, ethTx, appConfig)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "origin chain not registered")
 	})
@@ -220,14 +235,19 @@ func TestBridgingRequestedProcessor(t *testing.T) {
 		require.NotNil(t, destinationChainNonRegisteredMetadata)
 
 		claims := &oCore.BridgeClaims{}
-
-		appConfig := getAppConfig(false)
-		proc := NewEthBridgingRequestedProcessor(&core.EthTxSuccessProcessorMock{}, hclog.NewNullLogger())
-
-		err = proc.ValidateAndAddClaim(claims, &core.EthTx{
+		ethTx := &core.EthTx{
 			Metadata:      destinationChainNonRegisteredMetadata,
 			OriginChainID: common.ChainIDStrNexus,
-		}, appConfig)
+		}
+
+		appConfig := getAppConfig(false)
+		refundRequestProcessorMock := &core.EthTxSuccessRefundProcessorMock{}
+		refundRequestProcessorMock.On(
+			"HandleBridgingProcessorError", claims, ethTx, appConfig).Return(nil)
+
+		proc := NewEthBridgingRequestedProcessor(refundRequestProcessorMock, hclog.NewNullLogger())
+
+		err = proc.ValidateAndAddClaim(claims, ethTx, appConfig)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "destination chain not registered")
 	})
@@ -244,14 +264,19 @@ func TestBridgingRequestedProcessor(t *testing.T) {
 		require.NotNil(t, destinationChainNonRegisteredMetadata)
 
 		claims := &oCore.BridgeClaims{}
-
-		appConfig := getAppConfig(false)
-		proc := NewEthBridgingRequestedProcessor(&core.EthTxSuccessProcessorMock{}, hclog.NewNullLogger())
-
-		err = proc.ValidateAndAddClaim(claims, &core.EthTx{
+		ethTx := &core.EthTx{
 			Metadata:      destinationChainNonRegisteredMetadata,
 			OriginChainID: common.ChainIDStrNexus,
-		}, appConfig)
+		}
+
+		appConfig := getAppConfig(false)
+		refundRequestProcessorMock := &core.EthTxSuccessRefundProcessorMock{}
+		refundRequestProcessorMock.On(
+			"HandleBridgingProcessorError", claims, ethTx, appConfig).Return(nil)
+
+		proc := NewEthBridgingRequestedProcessor(refundRequestProcessorMock, hclog.NewNullLogger())
+
+		err = proc.ValidateAndAddClaim(claims, ethTx, appConfig)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "transaction direction not allowed")
 	})
@@ -273,14 +298,19 @@ func TestBridgingRequestedProcessor(t *testing.T) {
 		require.NotNil(t, moreThanMaxReceiversReceiversMetadata)
 
 		claims := &oCore.BridgeClaims{}
-
-		appConfig := getAppConfig(false)
-		proc := NewEthBridgingRequestedProcessor(&core.EthTxSuccessProcessorMock{}, hclog.NewNullLogger())
-
-		err = proc.ValidateAndAddClaim(claims, &core.EthTx{
+		ethTx := &core.EthTx{
 			Metadata:      moreThanMaxReceiversReceiversMetadata,
 			OriginChainID: common.ChainIDStrNexus,
-		}, appConfig)
+		}
+
+		appConfig := getAppConfig(false)
+		refundRequestProcessorMock := &core.EthTxSuccessRefundProcessorMock{}
+		refundRequestProcessorMock.On(
+			"HandleBridgingProcessorError", claims, ethTx, appConfig).Return(nil)
+
+		proc := NewEthBridgingRequestedProcessor(refundRequestProcessorMock, hclog.NewNullLogger())
+
+		err = proc.ValidateAndAddClaim(claims, ethTx, appConfig)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "number of receivers in metadata greater than maximum allowed")
 	})
@@ -299,14 +329,19 @@ func TestBridgingRequestedProcessor(t *testing.T) {
 		require.NotNil(t, metadata)
 
 		claims := &oCore.BridgeClaims{}
-
-		appConfig := getAppConfig(false)
-		proc := NewEthBridgingRequestedProcessor(&core.EthTxSuccessProcessorMock{}, hclog.NewNullLogger())
-
-		err = proc.ValidateAndAddClaim(claims, &core.EthTx{
+		ethTx := &core.EthTx{
 			Metadata:      metadata,
 			OriginChainID: common.ChainIDStrNexus,
-		}, appConfig)
+		}
+
+		appConfig := getAppConfig(false)
+		refundRequestProcessorMock := &core.EthTxSuccessRefundProcessorMock{}
+		refundRequestProcessorMock.On(
+			"HandleBridgingProcessorError", claims, ethTx, appConfig).Return(nil)
+
+		proc := NewEthBridgingRequestedProcessor(refundRequestProcessorMock, hclog.NewNullLogger())
+
+		err = proc.ValidateAndAddClaim(claims, ethTx, appConfig)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "bridging fee in metadata receivers is less than minimum")
 	})
@@ -326,15 +361,20 @@ func TestBridgingRequestedProcessor(t *testing.T) {
 		require.NotNil(t, metadata)
 
 		claims := &oCore.BridgeClaims{}
-
-		appConfig := getAppConfig(false)
-		proc := NewEthBridgingRequestedProcessor(&core.EthTxSuccessProcessorMock{}, hclog.NewNullLogger())
-
-		err = proc.ValidateAndAddClaim(claims, &core.EthTx{
+		ethTx := &core.EthTx{
 			Metadata:      metadata,
 			OriginChainID: common.ChainIDStrNexus,
 			Value:         common.DfmToWei(new(big.Int).SetUint64(utxoMinValue + minFeeForBridging + 100)),
-		}, appConfig)
+		}
+
+		appConfig := getAppConfig(false)
+		refundRequestProcessorMock := &core.EthTxSuccessRefundProcessorMock{}
+		refundRequestProcessorMock.On(
+			"HandleBridgingProcessorError", claims, ethTx, appConfig).Return(nil)
+
+		proc := NewEthBridgingRequestedProcessor(refundRequestProcessorMock, hclog.NewNullLogger())
+
+		err = proc.ValidateAndAddClaim(claims, ethTx, appConfig)
 		require.NoError(t, err)
 	})
 
@@ -353,14 +393,19 @@ func TestBridgingRequestedProcessor(t *testing.T) {
 		require.NotNil(t, utxoValueBelowMinInReceiversMetadata)
 
 		claims := &oCore.BridgeClaims{}
-
-		appConfig := getAppConfig(false)
-		proc := NewEthBridgingRequestedProcessor(&core.EthTxSuccessProcessorMock{}, hclog.NewNullLogger())
-
-		err = proc.ValidateAndAddClaim(claims, &core.EthTx{
+		ethTx := &core.EthTx{
 			Metadata:      utxoValueBelowMinInReceiversMetadata,
 			OriginChainID: common.ChainIDStrNexus,
-		}, appConfig)
+		}
+
+		appConfig := getAppConfig(false)
+		refundRequestProcessorMock := &core.EthTxSuccessRefundProcessorMock{}
+		refundRequestProcessorMock.On(
+			"HandleBridgingProcessorError", claims, ethTx, appConfig).Return(nil)
+
+		proc := NewEthBridgingRequestedProcessor(refundRequestProcessorMock, hclog.NewNullLogger())
+
+		err = proc.ValidateAndAddClaim(claims, ethTx, appConfig)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "found a utxo value below minimum value in metadata receivers")
 	})
@@ -380,14 +425,19 @@ func TestBridgingRequestedProcessor(t *testing.T) {
 		require.NotNil(t, invalidAddrInReceiversMetadata)
 
 		claims := &oCore.BridgeClaims{}
-
-		appConfig := getAppConfig(false)
-		proc := NewEthBridgingRequestedProcessor(&core.EthTxSuccessProcessorMock{}, hclog.NewNullLogger())
-
-		err = proc.ValidateAndAddClaim(claims, &core.EthTx{
+		ethTx := &core.EthTx{
 			Metadata:      invalidAddrInReceiversMetadata,
 			OriginChainID: common.ChainIDStrNexus,
-		}, appConfig)
+		}
+
+		appConfig := getAppConfig(false)
+		refundRequestProcessorMock := &core.EthTxSuccessRefundProcessorMock{}
+		refundRequestProcessorMock.On(
+			"HandleBridgingProcessorError", claims, ethTx, appConfig).Return(nil)
+
+		proc := NewEthBridgingRequestedProcessor(refundRequestProcessorMock, hclog.NewNullLogger())
+
+		err = proc.ValidateAndAddClaim(claims, ethTx, appConfig)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "found an invalid receiver addr in metadata")
 	})
@@ -407,14 +457,19 @@ func TestBridgingRequestedProcessor(t *testing.T) {
 		require.NotNil(t, invalidAddrInReceiversMetadata)
 
 		claims := &oCore.BridgeClaims{}
-
-		appConfig := getAppConfig(false)
-		proc := NewEthBridgingRequestedProcessor(&core.EthTxSuccessProcessorMock{}, hclog.NewNullLogger())
-
-		err = proc.ValidateAndAddClaim(claims, &core.EthTx{
+		ethTx := &core.EthTx{
 			Metadata:      invalidAddrInReceiversMetadata,
 			OriginChainID: common.ChainIDStrNexus,
-		}, appConfig)
+		}
+
+		appConfig := getAppConfig(false)
+		refundRequestProcessorMock := &core.EthTxSuccessRefundProcessorMock{}
+		refundRequestProcessorMock.On(
+			"HandleBridgingProcessorError", claims, ethTx, appConfig).Return(nil)
+
+		proc := NewEthBridgingRequestedProcessor(refundRequestProcessorMock, hclog.NewNullLogger())
+
+		err = proc.ValidateAndAddClaim(claims, ethTx, appConfig)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "found an invalid receiver addr in metadata")
 	})
@@ -440,16 +495,21 @@ func TestBridgingRequestedProcessor(t *testing.T) {
 		require.NotNil(t, validMetadata)
 
 		claims := &oCore.BridgeClaims{}
-
-		appConfig := getAppConfig(false)
-		proc := NewEthBridgingRequestedProcessor(&core.EthTxSuccessProcessorMock{}, hclog.NewNullLogger())
-
-		err = proc.ValidateAndAddClaim(claims, &core.EthTx{
+		ethTx := &core.EthTx{
 			Hash:          txHash,
 			Metadata:      validMetadata,
 			OriginChainID: common.ChainIDStrNexus,
 			Value:         common.DfmToWei(new(big.Int).SetUint64(utxoMinValue + minFeeForBridging - 1)),
-		}, appConfig)
+		}
+
+		appConfig := getAppConfig(false)
+		refundRequestProcessorMock := &core.EthTxSuccessRefundProcessorMock{}
+		refundRequestProcessorMock.On(
+			"HandleBridgingProcessorError", claims, ethTx, appConfig).Return(nil)
+
+		proc := NewEthBridgingRequestedProcessor(refundRequestProcessorMock, hclog.NewNullLogger())
+
+		err = proc.ValidateAndAddClaim(claims, ethTx, appConfig)
 
 		require.Error(t, err)
 		require.ErrorContains(t, err, "tx value is not equal to sum of receiver amounts + fee")
@@ -476,16 +536,21 @@ func TestBridgingRequestedProcessor(t *testing.T) {
 		require.NotNil(t, validMetadata)
 
 		claims := &oCore.BridgeClaims{}
-
-		appConfig := getAppConfig(false)
-		proc := NewEthBridgingRequestedProcessor(&core.EthTxSuccessProcessorMock{}, hclog.NewNullLogger())
-
-		err = proc.ValidateAndAddClaim(claims, &core.EthTx{
+		ethTx := &core.EthTx{
 			Hash:          txHash,
 			Metadata:      validMetadata,
 			OriginChainID: common.ChainIDStrNexus,
 			Value:         common.DfmToWei(new(big.Int).SetUint64(utxoMinValue + minFeeForBridging + 1)),
-		}, appConfig)
+		}
+
+		appConfig := getAppConfig(false)
+		refundRequestProcessorMock := &core.EthTxSuccessRefundProcessorMock{}
+		refundRequestProcessorMock.On(
+			"HandleBridgingProcessorError", claims, ethTx, appConfig).Return(nil)
+
+		proc := NewEthBridgingRequestedProcessor(refundRequestProcessorMock, hclog.NewNullLogger())
+
+		err = proc.ValidateAndAddClaim(claims, ethTx, appConfig)
 
 		require.Error(t, err)
 		require.ErrorContains(t, err, "tx value is not equal to sum of receiver amounts + fee")
@@ -505,14 +570,19 @@ func TestBridgingRequestedProcessor(t *testing.T) {
 		require.NotNil(t, feeInReceiversLessThanMinMetadata)
 
 		claims := &oCore.BridgeClaims{}
-
-		appConfig := getAppConfig(false)
-		proc := NewEthBridgingRequestedProcessor(&core.EthTxSuccessProcessorMock{}, hclog.NewNullLogger())
-
-		err = proc.ValidateAndAddClaim(claims, &core.EthTx{
+		ethTx := &core.EthTx{
 			Metadata:      feeInReceiversLessThanMinMetadata,
 			OriginChainID: common.ChainIDStrNexus,
-		}, appConfig)
+		}
+
+		appConfig := getAppConfig(false)
+		refundRequestProcessorMock := &core.EthTxSuccessRefundProcessorMock{}
+		refundRequestProcessorMock.On(
+			"HandleBridgingProcessorError", claims, ethTx, appConfig).Return(nil)
+
+		proc := NewEthBridgingRequestedProcessor(refundRequestProcessorMock, hclog.NewNullLogger())
+
+		err = proc.ValidateAndAddClaim(claims, ethTx, appConfig)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "bridging fee in metadata receivers is less than minimum")
 	})
@@ -537,16 +607,21 @@ func TestBridgingRequestedProcessor(t *testing.T) {
 		require.NotNil(t, validMetadata)
 
 		claims := &oCore.BridgeClaims{}
-
-		appConfig := getAppConfig(false)
-		proc := NewEthBridgingRequestedProcessor(&core.EthTxSuccessProcessorMock{}, hclog.NewNullLogger())
-
-		err = proc.ValidateAndAddClaim(claims, &core.EthTx{
+		ethTx := &core.EthTx{
 			Hash:          txHash,
 			Metadata:      validMetadata,
 			OriginChainID: common.ChainIDStrNexus,
 			Value:         common.DfmToWei(new(big.Int).SetUint64(maxAmountAllowedToBridge.Uint64() + minFeeForBridging)),
-		}, appConfig)
+		}
+
+		appConfig := getAppConfig(false)
+		refundRequestProcessorMock := &core.EthTxSuccessRefundProcessorMock{}
+		refundRequestProcessorMock.On(
+			"HandleBridgingProcessorError", claims, ethTx, appConfig).Return(nil)
+
+		proc := NewEthBridgingRequestedProcessor(refundRequestProcessorMock, hclog.NewNullLogger())
+
+		err = proc.ValidateAndAddClaim(claims, ethTx, appConfig)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "sum of receiver amounts + fee")
 		require.ErrorContains(t, err, "greater than maximum allowed")
@@ -572,7 +647,9 @@ func TestBridgingRequestedProcessor(t *testing.T) {
 		require.NotNil(t, validMetadata)
 
 		appConfig := getAppConfig(false)
-		proc := NewEthBridgingRequestedProcessor(&core.EthTxSuccessProcessorMock{}, hclog.NewNullLogger())
+		refundRequestProcessorMock := &core.EthTxSuccessRefundProcessorMock{}
+
+		proc := NewEthBridgingRequestedProcessor(refundRequestProcessorMock, hclog.NewNullLogger())
 
 		claims := &oCore.BridgeClaims{}
 		err = proc.ValidateAndAddClaim(claims, &core.EthTx{

--- a/oracle_eth/processor/tx_processors/success/bridging_requested_processor_test.go
+++ b/oracle_eth/processor/tx_processors/success/bridging_requested_processor_test.go
@@ -163,6 +163,8 @@ func TestBridgingRequestedProcessor(t *testing.T) {
 		refundRequestProcessorMock := &core.EthTxSuccessRefundProcessorMock{}
 		refundRequestProcessorMock.On(
 			"HandleBridgingProcessorError", claims, ethTx, appConfig).Return(nil)
+		refundRequestProcessorMock.On(
+			"HandleBridgingProcessorPreValidate", ethTx, appConfig).Return(nil)
 
 		proc := NewEthBridgingRequestedProcessor(refundRequestProcessorMock, hclog.NewNullLogger())
 
@@ -187,6 +189,8 @@ func TestBridgingRequestedProcessor(t *testing.T) {
 		refundRequestProcessorMock := &core.EthTxSuccessRefundProcessorMock{}
 		refundRequestProcessorMock.On(
 			"HandleBridgingProcessorError", claims, ethTx, appConfig).Return(nil)
+		refundRequestProcessorMock.On(
+			"HandleBridgingProcessorPreValidate", ethTx, appConfig).Return(nil)
 
 		proc := NewEthBridgingRequestedProcessor(refundRequestProcessorMock, hclog.NewNullLogger())
 
@@ -215,6 +219,8 @@ func TestBridgingRequestedProcessor(t *testing.T) {
 		refundRequestProcessorMock := &core.EthTxSuccessRefundProcessorMock{}
 		refundRequestProcessorMock.On(
 			"HandleBridgingProcessorError", claims, ethTx, appConfig).Return(nil)
+		refundRequestProcessorMock.On(
+			"HandleBridgingProcessorPreValidate", ethTx, appConfig).Return(nil)
 
 		proc := NewEthBridgingRequestedProcessor(refundRequestProcessorMock, hclog.NewNullLogger())
 
@@ -244,6 +250,8 @@ func TestBridgingRequestedProcessor(t *testing.T) {
 		refundRequestProcessorMock := &core.EthTxSuccessRefundProcessorMock{}
 		refundRequestProcessorMock.On(
 			"HandleBridgingProcessorError", claims, ethTx, appConfig).Return(nil)
+		refundRequestProcessorMock.On(
+			"HandleBridgingProcessorPreValidate", ethTx, appConfig).Return(nil)
 
 		proc := NewEthBridgingRequestedProcessor(refundRequestProcessorMock, hclog.NewNullLogger())
 
@@ -273,6 +281,8 @@ func TestBridgingRequestedProcessor(t *testing.T) {
 		refundRequestProcessorMock := &core.EthTxSuccessRefundProcessorMock{}
 		refundRequestProcessorMock.On(
 			"HandleBridgingProcessorError", claims, ethTx, appConfig).Return(nil)
+		refundRequestProcessorMock.On(
+			"HandleBridgingProcessorPreValidate", ethTx, appConfig).Return(nil)
 
 		proc := NewEthBridgingRequestedProcessor(refundRequestProcessorMock, hclog.NewNullLogger())
 
@@ -307,6 +317,8 @@ func TestBridgingRequestedProcessor(t *testing.T) {
 		refundRequestProcessorMock := &core.EthTxSuccessRefundProcessorMock{}
 		refundRequestProcessorMock.On(
 			"HandleBridgingProcessorError", claims, ethTx, appConfig).Return(nil)
+		refundRequestProcessorMock.On(
+			"HandleBridgingProcessorPreValidate", ethTx, appConfig).Return(nil)
 
 		proc := NewEthBridgingRequestedProcessor(refundRequestProcessorMock, hclog.NewNullLogger())
 
@@ -338,6 +350,8 @@ func TestBridgingRequestedProcessor(t *testing.T) {
 		refundRequestProcessorMock := &core.EthTxSuccessRefundProcessorMock{}
 		refundRequestProcessorMock.On(
 			"HandleBridgingProcessorError", claims, ethTx, appConfig).Return(nil)
+		refundRequestProcessorMock.On(
+			"HandleBridgingProcessorPreValidate", ethTx, appConfig).Return(nil)
 
 		proc := NewEthBridgingRequestedProcessor(refundRequestProcessorMock, hclog.NewNullLogger())
 
@@ -371,6 +385,8 @@ func TestBridgingRequestedProcessor(t *testing.T) {
 		refundRequestProcessorMock := &core.EthTxSuccessRefundProcessorMock{}
 		refundRequestProcessorMock.On(
 			"HandleBridgingProcessorError", claims, ethTx, appConfig).Return(nil)
+		refundRequestProcessorMock.On(
+			"HandleBridgingProcessorPreValidate", ethTx, appConfig).Return(nil)
 
 		proc := NewEthBridgingRequestedProcessor(refundRequestProcessorMock, hclog.NewNullLogger())
 
@@ -402,6 +418,8 @@ func TestBridgingRequestedProcessor(t *testing.T) {
 		refundRequestProcessorMock := &core.EthTxSuccessRefundProcessorMock{}
 		refundRequestProcessorMock.On(
 			"HandleBridgingProcessorError", claims, ethTx, appConfig).Return(nil)
+		refundRequestProcessorMock.On(
+			"HandleBridgingProcessorPreValidate", ethTx, appConfig).Return(nil)
 
 		proc := NewEthBridgingRequestedProcessor(refundRequestProcessorMock, hclog.NewNullLogger())
 
@@ -434,6 +452,8 @@ func TestBridgingRequestedProcessor(t *testing.T) {
 		refundRequestProcessorMock := &core.EthTxSuccessRefundProcessorMock{}
 		refundRequestProcessorMock.On(
 			"HandleBridgingProcessorError", claims, ethTx, appConfig).Return(nil)
+		refundRequestProcessorMock.On(
+			"HandleBridgingProcessorPreValidate", ethTx, appConfig).Return(nil)
 
 		proc := NewEthBridgingRequestedProcessor(refundRequestProcessorMock, hclog.NewNullLogger())
 
@@ -466,6 +486,8 @@ func TestBridgingRequestedProcessor(t *testing.T) {
 		refundRequestProcessorMock := &core.EthTxSuccessRefundProcessorMock{}
 		refundRequestProcessorMock.On(
 			"HandleBridgingProcessorError", claims, ethTx, appConfig).Return(nil)
+		refundRequestProcessorMock.On(
+			"HandleBridgingProcessorPreValidate", ethTx, appConfig).Return(nil)
 
 		proc := NewEthBridgingRequestedProcessor(refundRequestProcessorMock, hclog.NewNullLogger())
 
@@ -506,6 +528,8 @@ func TestBridgingRequestedProcessor(t *testing.T) {
 		refundRequestProcessorMock := &core.EthTxSuccessRefundProcessorMock{}
 		refundRequestProcessorMock.On(
 			"HandleBridgingProcessorError", claims, ethTx, appConfig).Return(nil)
+		refundRequestProcessorMock.On(
+			"HandleBridgingProcessorPreValidate", ethTx, appConfig).Return(nil)
 
 		proc := NewEthBridgingRequestedProcessor(refundRequestProcessorMock, hclog.NewNullLogger())
 
@@ -547,6 +571,8 @@ func TestBridgingRequestedProcessor(t *testing.T) {
 		refundRequestProcessorMock := &core.EthTxSuccessRefundProcessorMock{}
 		refundRequestProcessorMock.On(
 			"HandleBridgingProcessorError", claims, ethTx, appConfig).Return(nil)
+		refundRequestProcessorMock.On(
+			"HandleBridgingProcessorPreValidate", ethTx, appConfig).Return(nil)
 
 		proc := NewEthBridgingRequestedProcessor(refundRequestProcessorMock, hclog.NewNullLogger())
 
@@ -579,6 +605,8 @@ func TestBridgingRequestedProcessor(t *testing.T) {
 		refundRequestProcessorMock := &core.EthTxSuccessRefundProcessorMock{}
 		refundRequestProcessorMock.On(
 			"HandleBridgingProcessorError", claims, ethTx, appConfig).Return(nil)
+		refundRequestProcessorMock.On(
+			"HandleBridgingProcessorPreValidate", ethTx, appConfig).Return(nil)
 
 		proc := NewEthBridgingRequestedProcessor(refundRequestProcessorMock, hclog.NewNullLogger())
 
@@ -618,6 +646,8 @@ func TestBridgingRequestedProcessor(t *testing.T) {
 		refundRequestProcessorMock := &core.EthTxSuccessRefundProcessorMock{}
 		refundRequestProcessorMock.On(
 			"HandleBridgingProcessorError", claims, ethTx, appConfig).Return(nil)
+		refundRequestProcessorMock.On(
+			"HandleBridgingProcessorPreValidate", ethTx, appConfig).Return(nil)
 
 		proc := NewEthBridgingRequestedProcessor(refundRequestProcessorMock, hclog.NewNullLogger())
 
@@ -646,18 +676,22 @@ func TestBridgingRequestedProcessor(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, validMetadata)
 
-		appConfig := getAppConfig(false)
-		refundRequestProcessorMock := &core.EthTxSuccessRefundProcessorMock{}
-
-		proc := NewEthBridgingRequestedProcessor(refundRequestProcessorMock, hclog.NewNullLogger())
-
-		claims := &oCore.BridgeClaims{}
-		err = proc.ValidateAndAddClaim(claims, &core.EthTx{
+		ethTx := &core.EthTx{
 			Hash:          txHash,
 			Metadata:      validMetadata,
 			OriginChainID: common.ChainIDStrNexus,
 			Value:         common.DfmToWei(new(big.Int).SetUint64(utxoMinValue + minFeeForBridging)),
-		}, appConfig)
+		}
+
+		appConfig := getAppConfig(false)
+		refundRequestProcessorMock := &core.EthTxSuccessRefundProcessorMock{}
+		refundRequestProcessorMock.On(
+			"HandleBridgingProcessorPreValidate", ethTx, appConfig).Return(nil)
+
+		proc := NewEthBridgingRequestedProcessor(refundRequestProcessorMock, hclog.NewNullLogger())
+
+		claims := &oCore.BridgeClaims{}
+		err = proc.ValidateAndAddClaim(claims, ethTx, appConfig)
 		require.NoError(t, err)
 		require.True(t, claims.Count() == 1)
 		require.Len(t, claims.BridgingRequestClaims, 1)

--- a/oracle_eth/processor/tx_processors/success/refund_disabled_processor.go
+++ b/oracle_eth/processor/tx_processors/success/refund_disabled_processor.go
@@ -1,0 +1,39 @@
+package successtxprocessors
+
+import (
+	"fmt"
+
+	"github.com/Ethernal-Tech/apex-bridge/common"
+	cCore "github.com/Ethernal-Tech/apex-bridge/oracle_common/core"
+	"github.com/Ethernal-Tech/apex-bridge/oracle_eth/core"
+)
+
+var _ core.EthTxSuccessRefundProcessor = (*RefundDisabledProcessorImpl)(nil)
+
+type RefundDisabledProcessorImpl struct {
+}
+
+func NewRefundDisabledProcessor() *RefundDisabledProcessorImpl {
+	return &RefundDisabledProcessorImpl{}
+}
+
+func (*RefundDisabledProcessorImpl) GetType() common.BridgingTxType {
+	return common.TxTypeRefundRequest
+}
+
+func (*RefundDisabledProcessorImpl) PreValidate(tx *core.EthTx, appConfig *cCore.AppConfig) error {
+	return nil
+}
+
+func (p *RefundDisabledProcessorImpl) HandleBridgingProcessorError(
+	claims *cCore.BridgeClaims, tx *core.EthTx, appConfig *cCore.AppConfig,
+	err error, errContext string,
+) error {
+	return fmt.Errorf("%s. tx: %v, err: %w", errContext, tx, err)
+}
+
+func (p *RefundDisabledProcessorImpl) ValidateAndAddClaim(
+	claims *cCore.BridgeClaims, tx *core.EthTx, appConfig *cCore.AppConfig,
+) error {
+	return fmt.Errorf("refund is not enabled")
+}

--- a/oracle_eth/processor/tx_processors/success/refund_disabled_processor.go
+++ b/oracle_eth/processor/tx_processors/success/refund_disabled_processor.go
@@ -25,6 +25,11 @@ func (*RefundDisabledProcessorImpl) PreValidate(tx *core.EthTx, appConfig *cCore
 	return nil
 }
 
+func (*RefundDisabledProcessorImpl) HandleBridgingProcessorPreValidate(
+	tx *core.EthTx, appConfig *cCore.AppConfig) error {
+	return nil
+}
+
 func (p *RefundDisabledProcessorImpl) HandleBridgingProcessorError(
 	claims *cCore.BridgeClaims, tx *core.EthTx, appConfig *cCore.AppConfig,
 	err error, errContext string,

--- a/oracle_eth/processor/tx_processors/success/refund_request_processor.go
+++ b/oracle_eth/processor/tx_processors/success/refund_request_processor.go
@@ -34,6 +34,10 @@ func (*RefundRequestProcessorImpl) PreValidate(tx *core.EthTx, appConfig *cCore.
 func (p *RefundRequestProcessorImpl) ValidateAndAddClaim(
 	claims *cCore.BridgeClaims, tx *core.EthTx, appConfig *cCore.AppConfig,
 ) error {
+	if !appConfig.RefundEnabled {
+		return fmt.Errorf("refund is not enabled")
+	}
+
 	metadata, err := core.UnmarshalEthMetadata[core.RefundBridgingRequestEthMetadata](
 		tx.Metadata)
 	if err != nil {

--- a/oracle_eth/processor/tx_processors/success/refund_request_processor.go
+++ b/oracle_eth/processor/tx_processors/success/refund_request_processor.go
@@ -28,6 +28,11 @@ func (*RefundRequestProcessorImpl) GetType() common.BridgingTxType {
 }
 
 func (*RefundRequestProcessorImpl) PreValidate(tx *core.EthTx, appConfig *cCore.AppConfig) error {
+	return nil
+}
+
+func (*RefundRequestProcessorImpl) HandleBridgingProcessorPreValidate(
+	tx *core.EthTx, appConfig *cCore.AppConfig) error {
 	if tx.BatchTryCount > appConfig.TryCountLimits.MaxBatchTryCount ||
 		tx.SubmitTryCount > appConfig.TryCountLimits.MaxSubmitTryCount {
 		return fmt.Errorf(

--- a/oracle_eth/processor/tx_processors/success/refund_request_processor_test.go
+++ b/oracle_eth/processor/tx_processors/success/refund_request_processor_test.go
@@ -61,10 +61,10 @@ func TestRefundRequestedProcessor(t *testing.T) {
 	proc := NewRefundRequestProcessor(hclog.NewNullLogger())
 	disabledProc := NewRefundDisabledProcessor()
 
-	t.Run("Refund disabled - PreValidate", func(t *testing.T) {
+	t.Run("Refund disabled - HandleBridgingProcessorPreValidate", func(t *testing.T) {
 		appConfig := getAppConfig(false)
 
-		err := disabledProc.PreValidate(&core.EthTx{}, appConfig)
+		err := disabledProc.HandleBridgingProcessorPreValidate(&core.EthTx{}, appConfig)
 		require.NoError(t, err)
 	})
 
@@ -85,25 +85,25 @@ func TestRefundRequestedProcessor(t *testing.T) {
 		require.ErrorContains(t, err, "refund is not enabled")
 	})
 
-	t.Run("PreValidate - empty tx", func(t *testing.T) {
+	t.Run("HandleBridgingProcessorPreValidate - empty tx", func(t *testing.T) {
 		appConfig := getAppConfig(false)
 
-		err := proc.PreValidate(&core.EthTx{}, appConfig)
+		err := proc.HandleBridgingProcessorPreValidate(&core.EthTx{}, appConfig)
 		require.NoError(t, err)
 	})
 
-	t.Run("PreValidate - batchTryCount over", func(t *testing.T) {
+	t.Run("HandleBridgingProcessorPreValidate - batchTryCount over", func(t *testing.T) {
 		appConfig := getAppConfig(false)
 
-		err := proc.PreValidate(&core.EthTx{BatchTryCount: 1}, appConfig)
+		err := proc.HandleBridgingProcessorPreValidate(&core.EthTx{BatchTryCount: 1}, appConfig)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "try count exceeded")
 	})
 
-	t.Run("PreValidate - submitTryCount over", func(t *testing.T) {
+	t.Run("HandleBridgingProcessorPreValidate - submitTryCount over", func(t *testing.T) {
 		appConfig := getAppConfig(false)
 
-		err := proc.PreValidate(&core.EthTx{SubmitTryCount: 1}, appConfig)
+		err := proc.HandleBridgingProcessorPreValidate(&core.EthTx{SubmitTryCount: 1}, appConfig)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "try count exceeded")
 	})

--- a/oracle_eth/processor/tx_processors/success/refund_request_processor_test.go
+++ b/oracle_eth/processor/tx_processors/success/refund_request_processor_test.go
@@ -1,6 +1,7 @@
 package successtxprocessors
 
 import (
+	"fmt"
 	"math/big"
 	"testing"
 
@@ -58,15 +59,62 @@ func TestRefundRequestedProcessor(t *testing.T) {
 	}
 
 	proc := NewRefundRequestProcessor(hclog.NewNullLogger())
+	disabledProc := NewRefundDisabledProcessor()
 
-	t.Run("ValidateAndAddClaim empty tx - refund disabled", func(t *testing.T) {
-		claims := &oCore.BridgeClaims{}
-
+	t.Run("Refund disabled - PreValidate", func(t *testing.T) {
 		appConfig := getAppConfig(false)
 
-		err := proc.ValidateAndAddClaim(claims, &core.EthTx{}, appConfig)
+		err := disabledProc.PreValidate(&core.EthTx{}, appConfig)
+		require.NoError(t, err)
+	})
+
+	t.Run("Refund disabled - HandleBridgingProcessorError", func(t *testing.T) {
+		appConfig := getAppConfig(false)
+
+		err := disabledProc.HandleBridgingProcessorError(
+			&oCore.BridgeClaims{}, &core.EthTx{}, appConfig, fmt.Errorf("test err"), "")
+		require.Error(t, err)
+		require.ErrorContains(t, err, "test err")
+	})
+
+	t.Run("Refund disabled - ValidateAndAddClaim", func(t *testing.T) {
+		appConfig := getAppConfig(false)
+
+		err := disabledProc.ValidateAndAddClaim(&oCore.BridgeClaims{}, &core.EthTx{}, appConfig)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "refund is not enabled")
+	})
+
+	t.Run("PreValidate - empty tx", func(t *testing.T) {
+		appConfig := getAppConfig(false)
+
+		err := proc.PreValidate(&core.EthTx{}, appConfig)
+		require.NoError(t, err)
+	})
+
+	t.Run("PreValidate - batchTryCount over", func(t *testing.T) {
+		appConfig := getAppConfig(false)
+
+		err := proc.PreValidate(&core.EthTx{BatchTryCount: 1}, appConfig)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "try count exceeded")
+	})
+
+	t.Run("PreValidate - submitTryCount over", func(t *testing.T) {
+		appConfig := getAppConfig(false)
+
+		err := proc.PreValidate(&core.EthTx{SubmitTryCount: 1}, appConfig)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "try count exceeded")
+	})
+
+	t.Run("HandleBridgingProcessorError - empty ty", func(t *testing.T) {
+		appConfig := getAppConfig(false)
+
+		err := proc.HandleBridgingProcessorError(
+			&oCore.BridgeClaims{}, &core.EthTx{}, appConfig, nil, "")
+		require.Error(t, err)
+		require.ErrorContains(t, err, "unexpected end of JSON input")
 	})
 
 	t.Run("ValidateAndAddClaim empty tx", func(t *testing.T) {

--- a/oracle_eth/processor/tx_processors/success/refund_request_processor_test.go
+++ b/oracle_eth/processor/tx_processors/success/refund_request_processor_test.go
@@ -48,6 +48,7 @@ func TestRefundRequestedProcessor(t *testing.T) {
 			MaxReceiversPerBridgingRequest: 3,
 			MaxAmountAllowedToBridge:       maxAmountAllowedToBridge,
 		},
+		RefundEnabled: true,
 	}
 	appConfig.FillOut()
 

--- a/oracle_eth/processor/txs_processor/data.go
+++ b/oracle_eth/processor/txs_processor/data.go
@@ -59,15 +59,10 @@ func (pc *txProcessorsCollection) getSuccess(tx *core.EthTx, appConfig *cCore.Ap
 			return nil, err
 		}
 
-		if !appConfig.RefundEnabled && metadata.BridgingTxType == common.TxTypeRefundRequest {
-			return nil, fmt.Errorf("irrelevant tx. Tx type: %s", metadata.BridgingTxType)
-		}
-
 		txProcessor, relevant = pc.successTxProcessors[string(metadata.BridgingTxType)]
 		if !relevant {
-			if appConfig.RefundEnabled {
-				txProcessor = pc.successTxProcessors[string(common.TxTypeRefundRequest)]
-			} else {
+			txProcessor, relevant = pc.successTxProcessors[string(common.TxTypeRefundRequest)]
+			if !relevant {
 				return nil, fmt.Errorf("irrelevant tx. Tx type: %s", metadata.BridgingTxType)
 			}
 		}

--- a/oracle_eth/processor/txs_processor/data.go
+++ b/oracle_eth/processor/txs_processor/data.go
@@ -59,9 +59,17 @@ func (pc *txProcessorsCollection) getSuccess(tx *core.EthTx, appConfig *cCore.Ap
 			return nil, err
 		}
 
+		if !appConfig.RefundEnabled && metadata.BridgingTxType == common.TxTypeRefundRequest {
+			return nil, fmt.Errorf("irrelevant tx. Tx type: %s", metadata.BridgingTxType)
+		}
+
 		txProcessor, relevant = pc.successTxProcessors[string(metadata.BridgingTxType)]
 		if !relevant {
-			txProcessor = pc.successTxProcessors[string(common.TxTypeRefundRequest)]
+			if appConfig.RefundEnabled {
+				txProcessor = pc.successTxProcessors[string(common.TxTypeRefundRequest)]
+			} else {
+				return nil, fmt.Errorf("irrelevant tx. Tx type: %s", metadata.BridgingTxType)
+			}
 		}
 	} else {
 		txProcessor = pc.successTxProcessors[string(common.TxTypeHotWalletFund)]


### PR DESCRIPTION
If RefundEnabled flag in config is false, oracle should behave like before - not create Refund request claims, but mark the txs as invalid