### PR TITLE
AD-622 Reactor Audit Batcher - Batcher miscellaneous code concerns

### DIFF
--- a/batcher/batcher/cardano_chain_operations_test.go
+++ b/batcher/batcher/cardano_chain_operations_test.go
@@ -721,33 +721,33 @@ func Test_getNeededUtxos(t *testing.T) {
 	}
 
 	t.Run("pass", func(t *testing.T) {
-		result, err := getNeededUtxos(inputs, 65, 5, 5, 30, 1)
+		result, err := getNeededUtxos(inputs, 65, 5, 25, 1)
 
 		require.NoError(t, err)
 		require.Equal(t, inputs[:len(inputs)-1], result)
 
-		result, err = getNeededUtxos(inputs, 50, 6, 0, 2, 1)
+		result, err = getNeededUtxos(inputs, 50, 6, 2, 1)
 
 		require.NoError(t, err)
 		require.Equal(t, []*indexer.TxInputOutput{inputs[3], inputs[1]}, result)
 	})
 
 	t.Run("pass with change", func(t *testing.T) {
-		result, err := getNeededUtxos(inputs, 67, 4, 5, 30, 1)
+		result, err := getNeededUtxos(inputs, 67, 4, 25, 1)
 
 		require.NoError(t, err)
 		require.Equal(t, inputs, result)
 	})
 
 	t.Run("pass with at least", func(t *testing.T) {
-		result, err := getNeededUtxos(inputs, 10, 4, 5, 30, 3)
+		result, err := getNeededUtxos(inputs, 10, 4, 25, 3)
 
 		require.NoError(t, err)
 		require.Equal(t, inputs[:3], result)
 	})
 
 	t.Run("not enough sum", func(t *testing.T) {
-		_, err := getNeededUtxos(inputs, 160, 5, 5, 30, 1)
+		_, err := getNeededUtxos(inputs, 160, 5, 25, 1)
 		require.ErrorIs(t, err, errUTXOsCouldNotSelect)
 	})
 }

--- a/cardano/config.go
+++ b/cardano/config.go
@@ -21,9 +21,9 @@ type CardanoChainConfig struct {
 	SlotRoundingThreshold uint64                           `json:"slotRoundingThreshold"`
 	NoBatchPeriodPercent  float64                          `json:"noBatchPeriodPercent"`
 	UtxoMinAmount         uint64                           `json:"minUtxoAmount"`
-	MaxFeeUtxoCount       int                              `json:"maxFeeUtxoCount"`
-	MaxUtxoCount          int                              `json:"maxUtxoCount"`
-	TakeAtLeastUtxoCount  int                              `json:"takeAtLeastUtxoCount"`
+	MaxFeeUtxoCount       uint                             `json:"maxFeeUtxoCount"`
+	MaxUtxoCount          uint                             `json:"maxUtxoCount"`
+	TakeAtLeastUtxoCount  uint                             `json:"takeAtLeastUtxoCount"`
 }
 
 // GetChainType implements ChainSpecificConfig.

--- a/oracle_common/core/config.go
+++ b/oracle_common/core/config.go
@@ -64,9 +64,9 @@ type CardanoChainConfig struct {
 	NoBatchPeriodPercent  float64 `json:"noBatchPeriodPercent"`
 	UtxoMinAmount         uint64  `json:"utxoMinAmount"`
 	MinFeeForBridging     uint64  `json:"minFeeForBridging"`
-	MaxFeeUtxoCount       int     `json:"maxFeeUtxoCount"`
-	MaxUtxoCount          int     `json:"maxUtxoCount"`
-	TakeAtLeastUtxoCount  int     `json:"takeAtLeastUtxoCount"`
+	MaxFeeUtxoCount       uint    `json:"maxFeeUtxoCount"`
+	MaxUtxoCount          uint    `json:"maxUtxoCount"`
+	TakeAtLeastUtxoCount  uint    `json:"takeAtLeastUtxoCount"`
 }
 
 type SubmitConfig struct {


### PR DESCRIPTION
IF-FINDING-024 - Batcher miscellaneous code concerns

Description The following finding describes a set of miscellaneous code concerns found during the audit:
• Unnecessary casting and memory allocation here. DfmToWei() already accepts *big.Int type.
• Use go-ethereum’s Cmp instead of writing it’s implementation by hand (here).
• Using int instead of uint as data type for configuration fields that only can have positive values (here).
• getNeededUtxos() function (here) takes explicit parameters for MaxUtxoCount, TakeAtLeastUtxoCount and UtxoMinAmount. All of these mentioned function parameters belong to CardanoChainConfig which means that it is would be better to pass only config struct instead of separate fields. This will bring clarity to getNeededUtxos() function.  
**5 parameters is fine**
• Function getCardanoData() (here) has a misleading name since it is returning []eth.ValidatorChainData