### PR TITLE
AD-639, AD-638 Staking Interface and Exchange Rate

### DIFF
--- a/staking/core/config.go
+++ b/staking/core/config.go
@@ -18,6 +18,20 @@ type CardanoChainConfig struct {
 	StakingBridgingAddr StakingBridgingAddresses `json:"stakingBridgingAddrs"`
 }
 
+type StakingConfiguration struct {
+	Chain                  CardanoChainConfig `json:"chain"`
+	UsersRewardsPercentage float64            `json:"usersRewardsPercentage"`
+	PullTimeMilis          int64              `json:"pullTime"`
+}
+
+type StakingManagerConfiguration struct {
+	Chains                 map[string]*CardanoChainConfig `json:"chains"`
+	Logger                 logger.LoggerConfig            `json:"logger"`
+	DbsPath                string                         `json:"dbsPath"`
+	UsersRewardsPercentage float64                        `json:"usersRewardsPercentage"`
+	PullTimeMilis          int64                          `json:"pullTime"`
+}
+
 func (c CardanoChainConfig) GetNetworkMagic() uint32 {
 	return c.NetworkMagic
 }
@@ -27,18 +41,6 @@ func (c CardanoChainConfig) GetAddressesOfInterest() []string {
 		c.StakingBridgingAddr.StakingBridgingAddr,
 		c.StakingBridgingAddr.FeeAddress,
 	}, c.StakingAddresses...)
-}
-
-type StakingConfiguration struct {
-	Chain         CardanoChainConfig `json:"chain"`
-	PullTimeMilis int64              `json:"pullTime"`
-}
-
-type StakingManagerConfiguration struct {
-	Chains        map[string]*CardanoChainConfig `json:"chains"`
-	Logger        logger.LoggerConfig            `json:"logger"`
-	DbsPath       string                         `json:"dbsPath"`
-	PullTimeMilis int64                          `json:"pullTime"`
 }
 
 func (config *StakingManagerConfiguration) FillOut() {

--- a/staking/core/interfaces.go
+++ b/staking/core/interfaces.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"math/big"
 
 	"github.com/Ethernal-Tech/cardano-infrastructure/indexer"
 	"go.etcd.io/bbolt"
@@ -9,10 +10,31 @@ import (
 
 type StakingManager interface {
 	Start()
+	GetExchangeRate(chainID string) (float64, error)
+	ChooseStakeAddrForStaking(chainID string, amount *big.Int) (string, error)
+	ChooseStakeAddrForUnstaking(chainID string, amount *big.Int) (map[string]*big.Int, error)
+	Stake(chainID string, amount *big.Int, stakingAddress string) error
+	Unstake(chainID string, amount *big.Int, stakingAddress string) error
+	ReceiveReward(chainID string, reward *big.Int, stakingAddress string) error
 }
 
 type StakingComponent interface {
 	Start(ctx context.Context) error
+	GetExchangeRate() float64
+	ChooseStakeAddrForStaking(amount *big.Int) (string, error)
+	ChooseStakeAddrForUnstaking(amount *big.Int) (map[string]*big.Int, error)
+	Stake(amount *big.Int, stakingAddress string) error
+	Unstake(amount *big.Int, stakingAddress string) error
+	ReceiveReward(reward *big.Int, stakingAddress string) error
+}
+
+type StakingAddress interface {
+	GetAddress() string
+	GetTotalStTokens() *big.Int
+	GetTotalTokensWithRewards() *big.Int
+	Stake(amount *big.Int, exchangeRate float64) error
+	Unstake(amount *big.Int, exchangeRate float64) error
+	ReceiveReward(reward *big.Int) error
 }
 
 type CardanoTxsReceiver interface {

--- a/staking/core/test_mocks.go
+++ b/staking/core/test_mocks.go
@@ -1,0 +1,32 @@
+package core
+
+import (
+	ocCore "github.com/Ethernal-Tech/apex-bridge/oracle_common/core"
+	"github.com/stretchr/testify/mock"
+)
+
+type CardanoChainObserverMock struct {
+	mock.Mock
+}
+
+func (m *CardanoChainObserverMock) Start() error {
+	args := m.Called()
+
+	return args.Error(0)
+}
+
+func (m *CardanoChainObserverMock) Dispose() error {
+	args := m.Called()
+
+	return args.Error(0)
+}
+
+func (m *CardanoChainObserverMock) GetConfig() ocCore.ChainConfigReader {
+	args := m.Called()
+	return args.Get(0).(ocCore.ChainConfigReader) //nolint
+}
+
+func (m *CardanoChainObserverMock) ErrorCh() <-chan error {
+	args := m.Called()
+	return args.Get(0).(chan error) //nolint
+}

--- a/staking/staking/staking_address.go
+++ b/staking/staking/staking_address.go
@@ -1,0 +1,129 @@
+package stakingcomponent
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/Ethernal-Tech/apex-bridge/staking/core"
+)
+
+// StakingAddressImpl represents an address that delegates to a stake pool,
+// along with its associated token balances and user rewards distribution.
+//
+// Fields:
+//   - address: The staking address that delegates to a stake pool.
+//   - totalTokensWithRewards: The total tokens staked by users plus accumulated rewards.
+//   - totalStTokens: Total staked tokens (stTokens) issued to users by the bridge for this staking address.
+//   - usersRewardsPercentage: The percentage of rewards allocated to users
+//     staking through this address (value between 0 and 1).
+type StakingAddressImpl struct {
+	address                string
+	totalTokensWithRewards *big.Int
+	totalStTokens          *big.Int
+	usersRewardsPercentage float64
+}
+
+var _ core.StakingAddress = (*StakingAddressImpl)(nil)
+
+// NewStakingAddress creates a new StakingAddressImpl with the given address and user rewards percentage.
+// usersRewardsPercentage should be a value between 0 and 1 representing the share of rewards for users.
+func NewStakingAddress(address string, usersRewardsPercentage float64) (*StakingAddressImpl, error) {
+	if usersRewardsPercentage < 0 || usersRewardsPercentage > 1 {
+		return nil, fmt.Errorf("usersRewardsPercentage must be between 0 and 1")
+	}
+
+	return &StakingAddressImpl{
+		address:                address,
+		totalTokensWithRewards: big.NewInt(0),
+		totalStTokens:          big.NewInt(0),
+		usersRewardsPercentage: usersRewardsPercentage,
+	}, nil
+}
+
+func (sa *StakingAddressImpl) GetAddress() string {
+	return sa.address
+}
+
+func (sa *StakingAddressImpl) GetTotalStTokens() *big.Int {
+	return sa.totalStTokens
+}
+
+func (sa *StakingAddressImpl) GetTotalTokensWithRewards() *big.Int {
+	return sa.totalTokensWithRewards
+}
+
+// Staking address state is updated after receiving users' staked tokens.
+//
+// It increases the total tokens (including rewards) by the staked amount,
+// and mints the corresponding amount of stTokens based on the provided exchange rate.
+func (sa *StakingAddressImpl) Stake(amount *big.Int, exchangeRate float64) error {
+	if exchangeRate == 0 {
+		return fmt.Errorf("cannot stake tokens: exchange rate cannot be zero")
+	}
+
+	sa.totalTokensWithRewards.Add(sa.totalTokensWithRewards, amount)
+
+	amountFloat := new(big.Float).SetInt(amount)
+	stTokensToMintFloat := new(big.Float).Quo(amountFloat, big.NewFloat(exchangeRate))
+	stTokensToMint := new(big.Int)
+	stTokensToMint, _ = stTokensToMintFloat.Int(stTokensToMint)
+
+	sa.totalStTokens.Add(sa.totalStTokens, stTokensToMint)
+
+	return nil
+}
+
+// Unstake processes a user's request to withdraw staked tokens.
+//
+// It decreases the total stTokens by the specified amount and deducts the equivalent
+// underlying tokens (including rewards) based on the current exchange rate.
+func (sa *StakingAddressImpl) Unstake(amount *big.Int, exchangeRate float64) error {
+	if exchangeRate == 0 {
+		return fmt.Errorf("cannot unstake tokens: exchange rate cannot be zero")
+	}
+
+	if sa.totalStTokens.Cmp(amount) < 0 {
+		return fmt.Errorf(
+			"cannot unstake: requested stTokens (%s) exceeds available stTokens (%s)",
+			amount.String(),
+			sa.totalStTokens.String(),
+		)
+	}
+
+	amountFloat := new(big.Float).SetInt(amount)
+	stTokensToUnstakeFloat := new(big.Float).Mul(amountFloat, big.NewFloat(exchangeRate))
+	tokensToUnstake := new(big.Int)
+	tokensToUnstake, _ = stTokensToUnstakeFloat.Int(tokensToUnstake)
+
+	if sa.totalTokensWithRewards.Cmp(tokensToUnstake) < 0 {
+		return fmt.Errorf(
+			"cannot unstake: required tokens (%s) exceed available tokens with rewards (%s)",
+			tokensToUnstake.String(),
+			sa.totalTokensWithRewards.String(),
+		)
+	}
+
+	sa.totalTokensWithRewards.Sub(sa.totalTokensWithRewards, tokensToUnstake)
+	sa.totalStTokens.Sub(sa.totalStTokens, amount)
+
+	return nil
+}
+
+// This function should be called when the rewards account receives new tokens.
+// It calculates the portion of the reward allocated to users (based on usersRewardsPercentage)
+// and adds it to the total tokens including rewards.
+func (sa *StakingAddressImpl) ReceiveReward(reward *big.Int) error {
+	if sa.totalStTokens.Cmp(big.NewInt(0)) == 0 {
+		return fmt.Errorf("no staked tokens: reward cannot be distributed to users")
+	}
+
+	// Calculate user's share of the reward
+	rewardFloat := new(big.Float).SetInt(reward)
+	userRewardFloat := new(big.Float).Mul(rewardFloat, big.NewFloat(sa.usersRewardsPercentage))
+	userReward := new(big.Int)
+	userReward, _ = userRewardFloat.Int(userReward)
+
+	sa.totalTokensWithRewards.Add(sa.totalTokensWithRewards, userReward)
+
+	return nil
+}

--- a/staking/staking/staking_component.go
+++ b/staking/staking/staking_component.go
@@ -3,6 +3,9 @@ package stakingcomponent
 import (
 	"context"
 	"fmt"
+	"math/big"
+	"sort"
+	"sync"
 	"time"
 
 	oCore "github.com/Ethernal-Tech/apex-bridge/oracle_cardano/core"
@@ -13,6 +16,9 @@ import (
 type StakingComponentImpl struct {
 	config               *core.StakingConfiguration
 	cardanoChainObserver oCore.CardanoChainObserver
+	stakingAddresses     map[string]core.StakingAddress
+	exchangeRate         float64
+	mutex                sync.RWMutex
 	logger               hclog.Logger
 }
 
@@ -22,31 +28,222 @@ func NewStakingComponent(
 	config *core.StakingConfiguration,
 	cardanoChainObserver oCore.CardanoChainObserver,
 	logger hclog.Logger,
-) *StakingComponentImpl {
+) (*StakingComponentImpl, error) {
+	stakingAddresses := make(map[string]core.StakingAddress, len(config.Chain.StakingAddresses))
+
+	for _, addr := range config.Chain.StakingAddresses {
+		sa, err := NewStakingAddress(addr, config.UsersRewardsPercentage)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create staking address %s: %w", addr, err)
+		}
+
+		stakingAddresses[addr] = sa
+	}
+
 	return &StakingComponentImpl{
 		config:               config,
 		cardanoChainObserver: cardanoChainObserver,
+		stakingAddresses:     stakingAddresses,
+		exchangeRate:         1,
 		logger:               logger,
-	}
+	}, nil
 }
 
+// Start launches the staking component's background process.
+// It starts the Cardano chain observer and enters a loop that periodically executes staking logic.
+// The loop exits gracefully when the context is cancelled.
 func (sc *StakingComponentImpl) Start(ctx context.Context) error {
-	sc.logger.Debug("Starting Staking Component")
+	sc.logger.Debug("Starting Staking Component...")
 
-	err := sc.cardanoChainObserver.Start()
-	if err != nil {
-		return fmt.Errorf("failed to start observer for %s: %w", sc.cardanoChainObserver.GetConfig().GetChainID(), err)
+	// Start the Cardano chain observer
+	if err := sc.cardanoChainObserver.Start(); err != nil {
+		return fmt.Errorf("failed to start observer for chain %s: %w",
+			sc.cardanoChainObserver.GetConfig().GetChainID(), err)
 	}
 
-	waitTime := time.Millisecond * time.Duration(sc.config.PullTimeMilis)
+	waitInterval := time.Millisecond * time.Duration(sc.config.PullTimeMilis)
 
+	// Background loop that runs until context is cancelled
 	for {
 		select {
 		case <-ctx.Done():
+			sc.logger.Info("Staking Component shutting down...")
+
 			return nil
-		case <-time.After(waitTime):
+
+		case <-time.After(waitInterval):
+			sc.logger.Debug("Staking Component executing...")
+		}
+	}
+}
+
+// GetExchangeRate returns the current exchange rate between the native tokens and stTokens.
+func (sc *StakingComponentImpl) GetExchangeRate() float64 {
+	sc.mutex.RLock()
+	defer sc.mutex.RUnlock()
+
+	return sc.exchangeRate
+}
+
+// ChooseStakeAddrForStaking selects the staking address with the lowest current load.
+func (sc *StakingComponentImpl) ChooseStakeAddrForStaking(amount *big.Int) (string, error) {
+	if len(sc.stakingAddresses) == 0 {
+		return "", fmt.Errorf("no staking addresses configured for chainID %s", sc.config.Chain.ChainID)
+	}
+
+	minTotalTokens := new(big.Int)
+	addrForStaking := ""
+
+	for addr, stakeAddr := range sc.stakingAddresses {
+		totalTokens := stakeAddr.GetTotalTokensWithRewards()
+		if addrForStaking == "" || totalTokens.Cmp(minTotalTokens) < 0 {
+			minTotalTokens = totalTokens
+			addrForStaking = addr
+		}
+	}
+
+	return addrForStaking, nil
+}
+
+// ChooseStakeAddrForUnstaking selects the staking address with the most available tokens for unstaking.
+// Currently returns the address with the highest load.
+func (sc *StakingComponentImpl) ChooseStakeAddrForUnstaking(amount *big.Int) (map[string]*big.Int, error) {
+	if len(sc.stakingAddresses) == 0 {
+		return nil, fmt.Errorf("no staking addresses configured for chainID %s", sc.config.Chain.ChainID)
+	}
+
+	sorted := make([]core.StakingAddress, 0, len(sc.stakingAddresses))
+	for _, addr := range sc.stakingAddresses {
+		sorted = append(sorted, addr)
+	}
+
+	// Sort in descending order by total tokens with rewards
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].GetTotalTokensWithRewards().Cmp(sorted[j].GetTotalTokensWithRewards()) > 0
+	})
+
+	remaining := new(big.Int).Set(amount)
+	addrsForUnstake := make(map[string]*big.Int)
+
+	for _, addr := range sorted {
+		if remaining.Cmp(big.NewInt(0)) == 0 || addr.GetTotalTokensWithRewards().Cmp(big.NewInt(0)) == 0 {
+			break
 		}
 
-		sc.logger.Debug("Staking Component execute...")
+		// Determine how much can be unstaked from this address
+		toUnstake := new(big.Int).Set(minBigInt(remaining, addr.GetTotalTokensWithRewards()))
+		addrsForUnstake[addr.GetAddress()] = toUnstake
+		remaining.Sub(remaining, toUnstake)
 	}
+
+	if remaining.Cmp(big.NewInt(0)) > 0 {
+		available := new(big.Int).Sub(amount, remaining)
+
+		return nil, fmt.Errorf(
+			"insufficient funds to unstake %s tokens for chainID %s: only %s available",
+			amount.String(), sc.config.Chain.ChainID, available.String(),
+		)
+	}
+
+	return addrsForUnstake, nil
+}
+
+// Stake updates the staking address state after receiving a user's staked tokens.
+//
+// This function assumes the staking address has already received the actual tokens.
+func (sc *StakingComponentImpl) Stake(amount *big.Int, stakingAddress string) error {
+	sa, ok := sc.stakingAddresses[stakingAddress]
+	if !ok {
+		return fmt.Errorf("staking address %s not found for chainID %s", stakingAddress, sc.config.Chain.ChainID)
+	}
+
+	return sa.Stake(amount, sc.GetExchangeRate())
+}
+
+// Unstake processes a user's request to withdraw staked tokens from a specific staking address.
+func (sc *StakingComponentImpl) Unstake(amount *big.Int, stakingAddress string) error {
+	sa, ok := sc.stakingAddresses[stakingAddress]
+	if !ok {
+		return fmt.Errorf("staking address %s not found for chainID %s", stakingAddress, sc.config.Chain.ChainID)
+	}
+
+	return sa.Unstake(amount, sc.GetExchangeRate())
+}
+
+// ReceiveReward adds a reward amount to the specified staking address
+// and updates the global exchange rate accordingly.
+func (sc *StakingComponentImpl) ReceiveReward(reward *big.Int, stakingAddress string) error {
+	sa, ok := sc.stakingAddresses[stakingAddress]
+	if !ok {
+		return fmt.Errorf("staking address %s not found for chainID %s", stakingAddress, sc.config.Chain.ChainID)
+	}
+
+	if err := sa.ReceiveReward(reward); err != nil {
+		return fmt.Errorf("failed to distribute reward to staking address %s: %w", stakingAddress, err)
+	}
+
+	newExchangeRate, err := sc.calculateExchangeRate()
+	if err != nil {
+		return fmt.Errorf("failed to calculate exchange rate: %w", err)
+	}
+
+	sc.mutex.Lock()
+	sc.exchangeRate = newExchangeRate
+	sc.mutex.Unlock()
+
+	return nil
+}
+
+// calculateExchangeRate computes the exchange rate between total tokens (including rewards)
+// and the total staked tokens across all configured staking addresses.
+//
+// If no staking addresses are configured, it returns an error.
+// If the total staked tokens is zero, it returns the current exchange rate
+func (sc *StakingComponentImpl) calculateExchangeRate() (float64, error) {
+	if len(sc.stakingAddresses) == 0 {
+		return 0, fmt.Errorf("no staking addresses configured for chainID %s", sc.config.Chain.ChainID)
+	}
+
+	totalStTokens := sc.totalStTokens()
+	if totalStTokens.Cmp(big.NewInt(0)) == 0 {
+		return sc.GetExchangeRate(), nil
+	}
+
+	// Convert integers to floats for division
+	totalTokensWithRewardsFloat := new(big.Float).SetInt(sc.totalTokensWithRewards())
+	totalStTokensFloat := new(big.Float).SetInt(totalStTokens)
+
+	// Compute exchange rate: totalTokensWithRewards / totalStTokens
+	exchangeRate, _ := new(big.Float).Quo(totalTokensWithRewardsFloat, totalStTokensFloat).Float64()
+
+	return exchangeRate, nil
+}
+
+// totalTokensWithRewards returns the sum of total tokens including rewards
+// for all configured staking addresses.
+func (sc *StakingComponentImpl) totalTokensWithRewards() *big.Int {
+	sum := new(big.Int)
+	for _, addr := range sc.stakingAddresses {
+		sum.Add(sum, addr.GetTotalTokensWithRewards())
+	}
+
+	return sum
+}
+
+// totalStTokens returns the total number of staked tokens across all staking addresses.
+func (sc *StakingComponentImpl) totalStTokens() *big.Int {
+	sum := new(big.Int)
+	for _, addr := range sc.stakingAddresses {
+		sum.Add(sum, addr.GetTotalStTokens())
+	}
+
+	return sum
+}
+
+func minBigInt(a, b *big.Int) *big.Int {
+	if a.Cmp(b) <= 0 {
+		return a
+	}
+
+	return b
 }

--- a/staking/staking/staking_component_test.go
+++ b/staking/staking/staking_component_test.go
@@ -1,0 +1,580 @@
+package stakingcomponent
+
+import (
+	"math/big"
+	"slices"
+	"testing"
+
+	"github.com/Ethernal-Tech/apex-bridge/common"
+	"github.com/Ethernal-Tech/apex-bridge/staking/core"
+	"github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	ocCore "github.com/Ethernal-Tech/apex-bridge/oracle_common/core"
+)
+
+const usersRewardsPercentage = 0.2
+
+var stakingAddresses = []string{
+	"addr_test1wpphktxx847q52fzn5g7efu2ftwxzuwwjkgsuvgwn2m7sdgn0z1z1",
+	"addr_test1wpphktxx847q52fzn5g7efu2ftwxzuwwjkgsuvgwn2m7sdgn0z8z2",
+	"addr_test1wpphktxx847q52fzn5g7efu2ftwxzuwwjkgsuvgwn2m7sdgn0z8z3",
+}
+
+func TestCalculateExchangeRate(t *testing.T) {
+	stakeAmounts := []*big.Int{
+		big.NewInt(50_000_000_000_000_000),
+		big.NewInt(20_000_000_000_000_000),
+		big.NewInt(30_000_000_000_000_000),
+	}
+	rewards := []*big.Int{
+		big.NewInt(10_000_000_000),
+		big.NewInt(5_000_000_000),
+		big.NewInt(20_000_000_000),
+	}
+
+	tests := []struct {
+		name           string
+		configBuilder  func() core.StakingConfiguration
+		expectError    bool
+		expectedErrMsg string
+		expectedRate   float64
+		stakeAmount    map[string]*big.Int
+		unstakeAmount  map[string]*big.Int
+	}{
+		{
+			name:          "initial exchange rate without staking",
+			configBuilder: createConfigWithStAddrs,
+			expectedRate:  1,
+		},
+		{
+			name:          "exchange rate remains 1 after staking",
+			configBuilder: createConfigWithStAddrs,
+			expectedRate:  1,
+			stakeAmount: map[string]*big.Int{
+				stakingAddresses[0]: big.NewInt(5),
+			},
+		},
+		{
+			name:          "exchange rate remains 1 after both staking and unstaking",
+			configBuilder: createConfigWithStAddrs,
+			expectedRate:  1,
+			stakeAmount: map[string]*big.Int{
+				stakingAddresses[0]: big.NewInt(5),
+				stakingAddresses[1]: big.NewInt(4),
+			},
+			unstakeAmount: map[string]*big.Int{
+				stakingAddresses[0]: big.NewInt(3),
+				stakingAddresses[1]: big.NewInt(4),
+			},
+		},
+		{
+			name:           "exchange rate fails when no staking addresses configured",
+			configBuilder:  createConfigWithoutStAddrs,
+			expectError:    true,
+			expectedErrMsg: "no staking addresses configured",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			stakingComponent := newStakingComponent(t, test.configBuilder)
+			assert.NotNil(t, stakingComponent)
+
+			for addr, amount := range test.stakeAmount {
+				err := stakingComponent.Stake(amount, addr)
+				require.NoError(t, err)
+			}
+
+			checkExchangeRate(t, stakingComponent, test.expectedRate, test.expectError, test.expectedErrMsg)
+
+			for addr, amount := range test.unstakeAmount {
+				err := stakingComponent.Unstake(amount, addr)
+				require.NoError(t, err)
+			}
+
+			checkExchangeRate(t, stakingComponent, test.expectedRate, test.expectError, test.expectedErrMsg)
+		})
+	}
+
+	t.Run("calculate exchange rate after rewards are received", func(t *testing.T) {
+		sc := newStakingComponent(t, createConfigWithStAddrs)
+		assert.NotNil(t, sc)
+
+		expectedRates := calculateExpectedExchangeRates(stakeAmounts, rewards)
+
+		checkExchangeRate(t, sc, 1.0, false, "")
+
+		for i, amt := range stakeAmounts {
+			require.NoError(t, sc.Stake(amt, stakingAddresses[i]))
+			checkExchangeRate(t, sc, 1.0, false, "")
+		}
+
+		for i, reward := range rewards {
+			require.NoError(t, sc.ReceiveReward(reward, stakingAddresses[i]))
+			checkExchangeRate(t, sc, expectedRates[i], false, "")
+		}
+	})
+
+	t.Run("exchange rate after stake, rewards, and unstake", func(t *testing.T) {
+		sc := newStakingComponent(t, createConfigWithStAddrs)
+		assert.NotNil(t, sc)
+
+		expectedRates := calculateExpectedExchangeRates(stakeAmounts, rewards)
+
+		checkExchangeRate(t, sc, 1.0, false, "")
+
+		// stake all to one address
+		for _, amt := range stakeAmounts {
+			require.NoError(t, sc.Stake(amt, stakingAddresses[0]))
+			checkExchangeRate(t, sc, 1.0, false, "")
+		}
+
+		for idx, reward := range rewards {
+			require.NoError(t, sc.ReceiveReward(reward, stakingAddresses[0]))
+			checkExchangeRate(t, sc, expectedRates[idx], false, "")
+		}
+
+		for _, amount := range stakeAmounts {
+			require.NoError(t, sc.Unstake(amount, stakingAddresses[0]))
+			checkExchangeRate(t, sc, expectedRates[len(expectedRates)-1], false, "")
+		}
+
+		remainingTotalTokens := sc.totalTokensWithRewards()
+		assert.Zero(t, remainingTotalTokens.Cmp(big.NewInt(0)))
+	})
+}
+
+func TestChooseAddrForStaking(t *testing.T) {
+	tests := []struct {
+		name            string
+		configBuilder   func() core.StakingConfiguration
+		stakeTokens     map[string]*big.Int
+		amount          *big.Int
+		expectError     bool
+		expectedErrMsg  string
+		expectedAddress string
+	}{
+		{
+			name:            "choose addresses for staking when all staking addresses have zero tokens and rewards",
+			configBuilder:   createConfigWithStAddrs,
+			amount:          big.NewInt(5),
+			expectedAddress: "any",
+		},
+		{
+			name:          "choose addresses for staking after the first and third have been staked to",
+			configBuilder: createConfigWithStAddrs,
+			amount:        big.NewInt(3),
+			stakeTokens: map[string]*big.Int{
+				stakingAddresses[0]: big.NewInt(5),
+				stakingAddresses[2]: big.NewInt(5),
+			},
+			expectedAddress: stakingAddresses[1],
+		},
+		{
+			name:          "choose addresses for staking after staking on all addresses",
+			configBuilder: createConfigWithStAddrs,
+			amount:        big.NewInt(3),
+			stakeTokens: map[string]*big.Int{
+				stakingAddresses[0]: big.NewInt(5),
+				stakingAddresses[1]: big.NewInt(15),
+				stakingAddresses[2]: big.NewInt(3),
+			},
+			expectedAddress: stakingAddresses[2],
+		},
+		{
+			name:           "choose addresses for staking fails when no staking addresses configured",
+			configBuilder:  createConfigWithoutStAddrs,
+			amount:         big.NewInt(3),
+			expectError:    true,
+			expectedErrMsg: "no staking addresses configured",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			stakingComponent := newStakingComponent(t, test.configBuilder)
+			assert.NotNil(t, stakingComponent)
+
+			stakeTokens(t, stakingComponent, test.stakeTokens)
+
+			stakeAddr, err := stakingComponent.ChooseStakeAddrForStaking(test.amount)
+
+			if test.expectError {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), test.expectedErrMsg)
+			} else {
+				require.NoError(t, err)
+
+				if test.expectedAddress == "any" {
+					assert.True(t, slices.Contains(stakingAddresses, stakeAddr))
+				} else {
+					assert.Equal(t, test.expectedAddress, stakeAddr)
+				}
+			}
+		})
+	}
+}
+
+func TestChooseAddrForUnstaking(t *testing.T) {
+	tests := []struct {
+		name           string
+		configBuilder  func() core.StakingConfiguration
+		stakeTokens    map[string]*big.Int
+		amount         *big.Int
+		expectError    bool
+		expectedErrMsg string
+		expectedResult map[string]*big.Int
+	}{
+		{
+			name:          "choose one address for unstaking",
+			configBuilder: createConfigWithStAddrs,
+			amount:        big.NewInt(5),
+			stakeTokens: map[string]*big.Int{
+				stakingAddresses[0]: big.NewInt(6),
+				stakingAddresses[1]: big.NewInt(7),
+				stakingAddresses[2]: big.NewInt(2),
+			},
+			expectedResult: map[string]*big.Int{
+				stakingAddresses[1]: big.NewInt(5),
+			},
+		},
+		{
+			name:          "choose two addresses for unstaking",
+			configBuilder: createConfigWithStAddrs,
+			amount:        big.NewInt(10),
+			stakeTokens: map[string]*big.Int{
+				stakingAddresses[0]: big.NewInt(6),
+				stakingAddresses[1]: big.NewInt(7),
+				stakingAddresses[2]: big.NewInt(2),
+			},
+			expectedResult: map[string]*big.Int{
+				stakingAddresses[1]: big.NewInt(7),
+				stakingAddresses[0]: big.NewInt(3),
+			},
+		},
+		{
+			name:          "choose two addresses for unstaking",
+			configBuilder: createConfigWithStAddrs,
+			amount:        big.NewInt(14),
+			stakeTokens: map[string]*big.Int{
+				stakingAddresses[0]: big.NewInt(6),
+				stakingAddresses[1]: big.NewInt(7),
+				stakingAddresses[2]: big.NewInt(2),
+			},
+			expectedResult: map[string]*big.Int{
+				stakingAddresses[1]: big.NewInt(7),
+				stakingAddresses[0]: big.NewInt(6),
+				stakingAddresses[2]: big.NewInt(1),
+			},
+		},
+		{
+			name:           "unstake zero tokens",
+			configBuilder:  createConfigWithStAddrs,
+			amount:         big.NewInt(0),
+			expectedResult: map[string]*big.Int{},
+		},
+		{
+			name:          "choose address for unstaking fails when there is not enough funds",
+			configBuilder: createConfigWithStAddrs,
+			amount:        big.NewInt(16),
+			stakeTokens: map[string]*big.Int{
+				stakingAddresses[0]: big.NewInt(6),
+				stakingAddresses[1]: big.NewInt(7),
+				stakingAddresses[2]: big.NewInt(2),
+			},
+			expectError:    true,
+			expectedErrMsg: "insufficient funds to unstake",
+		},
+		{
+			name:           "choose address for unstaking fails when no staking addresses configured",
+			configBuilder:  createConfigWithoutStAddrs,
+			amount:         big.NewInt(3),
+			expectError:    true,
+			expectedErrMsg: "no staking addresses configured",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			stakingComponent := newStakingComponent(t, test.configBuilder)
+			assert.NotNil(t, stakingComponent)
+
+			stakeTokens(t, stakingComponent, test.stakeTokens)
+
+			stakeAddr, err := stakingComponent.ChooseStakeAddrForUnstaking(test.amount)
+
+			if test.expectError {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), test.expectedErrMsg)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, test.expectedResult, stakeAddr)
+			}
+		})
+	}
+}
+
+func TestStake(t *testing.T) {
+	t.Run("stake to valid address updates state correctly", func(t *testing.T) {
+		sc := newStakingComponent(t, createConfigWithStAddrs)
+		assert.NotNil(t, sc)
+
+		amount := big.NewInt(1_000_000_000_000_000) // 1 token
+		addr := stakingAddresses[0]
+
+		initialExchangeRate := sc.GetExchangeRate()
+		assert.Equal(t, float64(1), initialExchangeRate)
+
+		err := sc.Stake(amount, addr)
+		require.NoError(t, err)
+
+		sa := sc.stakingAddresses[addr]
+		assert.Equal(t, amount.String(), sa.GetTotalTokensWithRewards().String())
+		assert.Equal(t, amount.String(), sa.GetTotalStTokens().String()) // 1:1 exchange rate
+	})
+
+	t.Run("stake fails with unknown staking address", func(t *testing.T) {
+		sc := newStakingComponent(t, createConfigWithStAddrs)
+		assert.NotNil(t, sc)
+
+		err := sc.Stake(big.NewInt(1_000), "unknown_address")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("stake fails when exchange rate is 0", func(t *testing.T) {
+		sc := newStakingComponent(t, createConfigWithStAddrs)
+		assert.NotNil(t, sc)
+
+		addr := stakingAddresses[0]
+
+		// manually override exchange rate to simulate 0
+		sc.mutex.Lock()
+		sc.exchangeRate = 0
+		sc.mutex.Unlock()
+
+		err := sc.Stake(big.NewInt(1_000), addr)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "exchange rate cannot be zero")
+	})
+}
+
+func TestUnstake(t *testing.T) {
+	t.Run("unstake successfully with valid address and sufficient balance", func(t *testing.T) {
+		sc := newStakingComponent(t, createConfigWithStAddrs)
+		assert.NotNil(t, sc)
+
+		addr := stakingAddresses[0]
+		stakeAmount := big.NewInt(1_000_000_000_000_000) // 1 token
+
+		// Stake first
+		require.NoError(t, sc.Stake(stakeAmount, addr))
+
+		// Unstake the same amount of stTokens (1:1 exchange rate)
+		require.NoError(t, sc.Unstake(stakeAmount, addr))
+
+		sa := sc.stakingAddresses[addr]
+		assert.Zero(t, sa.GetTotalTokensWithRewards().Cmp(big.NewInt(0)))
+		assert.Zero(t, sa.GetTotalStTokens().Cmp(big.NewInt(0)))
+	})
+
+	t.Run("fail to unstake from unknown address", func(t *testing.T) {
+		sc := newStakingComponent(t, createConfigWithStAddrs)
+		err := sc.Unstake(big.NewInt(1000), "unknown_address")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("fail to unstake with zero exchange rate", func(t *testing.T) {
+		sc := newStakingComponent(t, createConfigWithStAddrs)
+		addr := stakingAddresses[0]
+
+		// Simulate staking
+		require.NoError(t, sc.Stake(big.NewInt(1_000), addr))
+
+		// Force exchange rate to 0
+		sc.mutex.Lock()
+		sc.exchangeRate = 0
+		sc.mutex.Unlock()
+
+		err := sc.Unstake(big.NewInt(100), addr)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "exchange rate cannot be zero")
+	})
+
+	t.Run("fail to unstake more stTokens than available", func(t *testing.T) {
+		sc := newStakingComponent(t, createConfigWithStAddrs)
+		addr := stakingAddresses[0]
+
+		require.NoError(t, sc.Stake(big.NewInt(1_000), addr))
+
+		// Try to unstake more than was staked
+		err := sc.Unstake(big.NewInt(2_000), addr)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "exceeds available stTokens")
+	})
+
+	t.Run("fail to unstake if underlying tokens with rewards are insufficient", func(t *testing.T) {
+		sc := newStakingComponent(t, createConfigWithStAddrs)
+		addr := stakingAddresses[0]
+
+		// Stake 1000 tokens
+		require.NoError(t, sc.Stake(big.NewInt(1_000), addr))
+
+		// Simulate reduction of totalTokensWithRewards to a small value
+		sa := sc.stakingAddresses[addr]
+		sa.(*StakingAddressImpl).totalTokensWithRewards = big.NewInt(500)
+
+		err := sc.Unstake(big.NewInt(1_000), addr)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "exceed available tokens with rewards")
+	})
+}
+
+func TestReceiveReward(t *testing.T) {
+	t.Run("successfully distribute reward and update exchange rate", func(t *testing.T) {
+		sc := newStakingComponent(t, createConfigWithStAddrs)
+		addr := stakingAddresses[0]
+		stakeAmount := big.NewInt(1_000_000_000_000_000)
+		reward := big.NewInt(1_000_000_000)
+
+		// Stake first
+		require.NoError(t, sc.Stake(stakeAmount, addr))
+		initialRate := sc.GetExchangeRate()
+		assert.Equal(t, 1.0, initialRate)
+
+		// Receive reward
+		err := sc.ReceiveReward(reward, addr)
+		require.NoError(t, err)
+
+		// Check exchange rate increased
+		newRate := sc.GetExchangeRate()
+		assert.Greater(t, newRate, initialRate)
+
+		// Check that tokens with rewards increased
+		sa := sc.stakingAddresses[addr]
+		assert.True(t, sa.GetTotalTokensWithRewards().Cmp(stakeAmount) > 0)
+	})
+
+	t.Run("fail to distribute reward if no stTokens are present", func(t *testing.T) {
+		sc := newStakingComponent(t, createConfigWithStAddrs)
+		addr := stakingAddresses[0]
+		reward := big.NewInt(1_000_000_000)
+
+		err := sc.ReceiveReward(reward, addr)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "reward cannot be distributed")
+	})
+
+	t.Run("fail to distribute reward to unknown address", func(t *testing.T) {
+		sc := newStakingComponent(t, createConfigWithStAddrs)
+		reward := big.NewInt(1_000_000_000)
+
+		err := sc.ReceiveReward(reward, "nonexistent_address")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func newStakingComponent(t *testing.T, configBuilder func() core.StakingConfiguration) *StakingComponentImpl {
+	t.Helper()
+
+	observer := core.CardanoChainObserverMock{}
+	cfg := configBuilder()
+
+	sc, err := NewStakingComponent(&cfg, &observer, hclog.Default())
+	require.NoError(t, err)
+
+	return sc
+}
+
+func stakeTokens(t *testing.T, sc *StakingComponentImpl, tokens map[string]*big.Int) {
+	t.Helper()
+
+	for _, addr := range sc.stakingAddresses {
+		if amount, ok := tokens[addr.GetAddress()]; ok {
+			require.NoError(t, addr.Stake(amount, 1))
+		}
+	}
+}
+
+func createConfigWithStAddrs() core.StakingConfiguration {
+	return createStakingConfig(stakingAddresses)
+}
+
+func createConfigWithoutStAddrs() core.StakingConfiguration {
+	return createStakingConfig([]string{})
+}
+
+func createStakingConfig(stakingAddresses []string) core.StakingConfiguration {
+	return core.StakingConfiguration{
+		Chain: core.CardanoChainConfig{
+			BaseCardanoChainConfig: ocCore.BaseCardanoChainConfig{
+				ChainID:                common.ChainIDStrCardano,
+				NetworkAddress:         "localhost:5500",
+				StartBlockHash:         "",
+				StartSlot:              0,
+				ConfirmationBlockCount: 10,
+			},
+			ChainType:        "Cardano",
+			NetworkMagic:     2,
+			StakingAddresses: stakingAddresses,
+			StakingBridgingAddr: core.StakingBridgingAddresses{
+				StakingBridgingAddr: "addr_test1wpphktxx847q52fzn5g7efu2ftwxzuwwjkgsuvgwn2m7sdgn0z8zg",
+				FeeAddress:          "addr_test1wz4f8kcdy3yue80gq5qmd4902pu8n3wf0k35m54k7g2qmsggfjqck",
+			},
+		},
+		PullTimeMilis:          1000,
+		UsersRewardsPercentage: usersRewardsPercentage,
+	}
+}
+
+func checkExchangeRate(t *testing.T, stakingComponent *StakingComponentImpl, expectedRate float64, expectError bool, expectedErrMsg string) {
+	t.Helper()
+
+	rate, err := stakingComponent.calculateExchangeRate()
+
+	if expectError {
+		require.Error(t, err)
+		require.Contains(t, err.Error(), expectedErrMsg)
+	} else {
+		require.NoError(t, err)
+		assert.Equal(t, expectedRate, rate)
+	}
+}
+
+func sumBigInts(values []*big.Int) *big.Int {
+	total := big.NewInt(0)
+	for _, v := range values {
+		total.Add(total, v)
+	}
+
+	return total
+}
+
+func calculateExpectedExchangeRates(stakeAmts, rewards []*big.Int) []float64 {
+	totalTokens := sumBigInts(stakeAmts)
+	totalStaked := new(big.Int).Set(totalTokens)
+	result := make([]float64, 0, len(rewards))
+
+	for _, reward := range rewards {
+		// Apply user rewards percentage
+		rewardFloat := new(big.Float).SetInt(reward)
+		usersRewardFloat := new(big.Float).Mul(big.NewFloat(usersRewardsPercentage), rewardFloat)
+
+		usersReward := new(big.Int)
+		usersReward, _ = usersRewardFloat.Int(usersReward)
+
+		totalTokens.Add(totalTokens, usersReward)
+
+		totalTokensFloat := new(big.Float).SetInt(totalTokens)
+		totalStakedFloat := new(big.Float).SetInt(totalStaked)
+		exRate, _ := new(big.Float).Quo(totalTokensFloat, totalStakedFloat).Float64()
+
+		result = append(result, exRate)
+	}
+
+	return result
+}

--- a/staking/staking_manager/staking_manager_test.go
+++ b/staking/staking_manager/staking_manager_test.go
@@ -1,0 +1,332 @@
+package stakingmanager
+
+import (
+	"context"
+	"encoding/json"
+	"math/big"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/Ethernal-Tech/apex-bridge/common"
+	"github.com/Ethernal-Tech/apex-bridge/staking/core"
+	"github.com/Ethernal-Tech/cardano-infrastructure/indexer"
+	"github.com/Ethernal-Tech/cardano-infrastructure/logger"
+	"github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	ocCore "github.com/Ethernal-Tech/apex-bridge/oracle_common/core"
+	databaseaccess "github.com/Ethernal-Tech/apex-bridge/staking/database_access"
+)
+
+var stakingAddresses = []string{
+	"addr_test1wpphktxx847q52fzn5g7efu2ftwxzuwwjkgsuvgwn2m7sdgn0z1z1",
+	"addr_test1wpphktxx847q52fzn5g7efu2ftwxzuwwjkgsuvgwn2m7sdgn0z8z2",
+}
+
+func TestStakingManagerConfig(t *testing.T) {
+	testDir := createTempDir(t)
+	defer os.RemoveAll(testDir)
+
+	expectedConfig := createConfigWithStAddrs(testDir)
+	configFilePath := filepath.Join(testDir, "config.json")
+
+	writeJSONFile(t, configFilePath, expectedConfig)
+
+	loadedConfig, err := common.LoadConfig[core.StakingManagerConfiguration](configFilePath, "")
+	require.NoError(t, err)
+	loadedConfig.FillOut()
+
+	assert.Equal(t, expectedConfig.DbsPath, loadedConfig.DbsPath)
+	assert.Equal(t, expectedConfig.PullTimeMilis, loadedConfig.PullTimeMilis)
+	assert.Equal(t, expectedConfig.Logger, loadedConfig.Logger)
+
+	for chainID, chainConfig := range loadedConfig.Chains {
+		expectedChainConfig, ok := expectedConfig.Chains[chainID]
+		assert.True(t, ok)
+		assert.Equal(t, expectedChainConfig, chainConfig)
+	}
+}
+
+func TestGetExchangeRate(t *testing.T) {
+	testDir := createTempDir(t)
+	defer os.RemoveAll(testDir)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	dbPath := filepath.Join(testDir, "temp_test.db")
+	indexerDbs := map[string]indexer.Database{
+		common.ChainIDStrPrime: &indexer.DatabaseMock{},
+	}
+
+	tests := []struct {
+		name           string
+		configBuilder  func(string) core.StakingManagerConfiguration
+		chainID        string
+		expectError    bool
+		expectedErrMsg string
+		expectedRate   float64
+	}{
+		{
+			name:          "cardano exchange rate returns initial value",
+			configBuilder: createConfigWithStAddrs,
+			chainID:       common.ChainIDStrCardano,
+			expectedRate:  1,
+		},
+		{
+			name:          "prime exchange rate returns initial value",
+			configBuilder: createConfigWithStAddrs,
+			chainID:       common.ChainIDStrPrime,
+			expectedRate:  1,
+		},
+		{
+			name:           "exchange rate fails for non-existing chain",
+			configBuilder:  createConfigWithStAddrs,
+			chainID:        common.ChainIDStrNexus,
+			expectError:    true,
+			expectedErrMsg: "failed to get exchange rate: staking component not found",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Cleanup(func() {
+				os.Remove(dbPath)
+			})
+
+			smConfig := test.configBuilder(testDir)
+
+			stakingDB, err := databaseaccess.NewDatabase(dbPath, &smConfig)
+			require.NoError(t, err)
+
+			stakingManager, err := NewStakingManager(ctx, &smConfig, stakingDB, indexerDbs, hclog.Default())
+			require.NoError(t, err)
+
+			rate, err := stakingManager.GetExchangeRate(test.chainID)
+
+			if test.expectError {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), test.expectedErrMsg)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, test.expectedRate, rate)
+			}
+		})
+	}
+}
+
+func TestChooseAddrForStaking(t *testing.T) {
+	testDir := createTempDir(t)
+	defer os.RemoveAll(testDir)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	dbPath := filepath.Join(testDir, "temp_test.db")
+	indexerDbs := map[string]indexer.Database{
+		common.ChainIDStrPrime: &indexer.DatabaseMock{},
+	}
+
+	tests := []struct {
+		name           string
+		configBuilder  func(string) core.StakingManagerConfiguration
+		chainID        string
+		expectError    bool
+		expectedErrMsg string
+	}{
+		{
+			name:          "cardano: choose address for staking when all staking addresses have zero tokens and rewards",
+			configBuilder: createConfigWithStAddrs,
+			chainID:       common.ChainIDStrCardano,
+		},
+		{
+			name:          "prime: choose address for staking when all staking addresses have zero tokens and rewards",
+			configBuilder: createConfigWithStAddrs,
+			chainID:       common.ChainIDStrPrime,
+		},
+		{
+			name:           "choose address for staking fails for non-existing chain",
+			configBuilder:  createConfigWithStAddrs,
+			chainID:        common.ChainIDStrNexus,
+			expectError:    true,
+			expectedErrMsg: "failed to choose stake address for staking: staking component not found",
+		},
+		{
+			name:           "choose address for staking fails when no staking addresses configured",
+			configBuilder:  createConfigWithoutStAddrs,
+			chainID:        common.ChainIDStrPrime,
+			expectError:    true,
+			expectedErrMsg: "no staking addresses configured",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Cleanup(func() {
+				os.Remove(dbPath)
+			})
+
+			smConfig := test.configBuilder(testDir)
+
+			stakingDB, err := databaseaccess.NewDatabase(dbPath, &smConfig)
+			require.NoError(t, err)
+
+			stakingManager, err := NewStakingManager(ctx, &smConfig, stakingDB, indexerDbs, hclog.Default())
+			require.NoError(t, err)
+
+			stakeAddr, err := stakingManager.ChooseStakeAddrForStaking(test.chainID, big.NewInt(5))
+
+			if test.expectError {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), test.expectedErrMsg)
+			} else {
+				require.NoError(t, err)
+				assert.True(t, slices.Contains(stakingAddresses, stakeAddr))
+			}
+		})
+	}
+}
+
+func TestChooseAddrForUnstaking(t *testing.T) {
+	testDir := createTempDir(t)
+	defer os.RemoveAll(testDir)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	dbPath := filepath.Join(testDir, "temp_test.db")
+	indexerDbs := map[string]indexer.Database{
+		common.ChainIDStrPrime: &indexer.DatabaseMock{},
+	}
+
+	tests := []struct {
+		name           string
+		configBuilder  func(string) core.StakingManagerConfiguration
+		chainID        string
+		expectError    bool
+		expectedErrMsg string
+	}{
+		{
+			name:           "cardano: choose address for unstaking when all staking addresses have zero tokens",
+			configBuilder:  createConfigWithStAddrs,
+			chainID:        common.ChainIDStrCardano,
+			expectedErrMsg: "insufficient funds to unstake",
+		},
+		{
+			name:           "prime: choose address for unstaking when all staking addresses have zero tokens",
+			configBuilder:  createConfigWithStAddrs,
+			chainID:        common.ChainIDStrPrime,
+			expectedErrMsg: "insufficient funds to unstake",
+		},
+		{
+			name:           "choose address for unstaking fails for non-existing chain",
+			configBuilder:  createConfigWithStAddrs,
+			chainID:        common.ChainIDStrNexus,
+			expectedErrMsg: "failed to choose stake address for unstaking: staking component not found",
+		},
+		{
+			name:           "choose address for unstaking fails when no staking addresses configured",
+			configBuilder:  createConfigWithoutStAddrs,
+			chainID:        common.ChainIDStrPrime,
+			expectedErrMsg: "no staking addresses configured",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Cleanup(func() {
+				os.Remove(dbPath)
+			})
+
+			smConfig := test.configBuilder(testDir)
+
+			stakingDB, err := databaseaccess.NewDatabase(dbPath, &smConfig)
+			require.NoError(t, err)
+
+			stakingManager, err := NewStakingManager(ctx, &smConfig, stakingDB, indexerDbs, hclog.Default())
+			require.NoError(t, err)
+
+			_, err = stakingManager.ChooseStakeAddrForUnstaking(test.chainID, big.NewInt(5))
+
+			require.Error(t, err)
+			require.Contains(t, err.Error(), test.expectedErrMsg)
+		})
+	}
+}
+
+func createTempDir(t *testing.T) string {
+	t.Helper()
+
+	dir, err := os.MkdirTemp("", "staking-test-*")
+	require.NoError(t, err)
+
+	return dir
+}
+
+func writeJSONFile(t *testing.T, path string, data any) {
+	t.Helper()
+
+	bytes, err := json.Marshal(data)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, bytes, 0770))
+}
+
+func createConfigWithStAddrs(dir string) core.StakingManagerConfiguration {
+	return createStakingManagerConfig(dir, stakingAddresses)
+}
+
+func createConfigWithoutStAddrs(testDir string) core.StakingManagerConfiguration {
+	return createStakingManagerConfig(testDir, []string{})
+}
+
+func createStakingManagerConfig(testDir string, stakingAddresses []string) core.StakingManagerConfiguration {
+	return core.StakingManagerConfiguration{
+		Chains: map[string]*core.CardanoChainConfig{
+			common.ChainIDStrCardano: {
+				BaseCardanoChainConfig: ocCore.BaseCardanoChainConfig{
+					ChainID:                common.ChainIDStrCardano,
+					NetworkAddress:         "localhost:5500",
+					StartBlockHash:         "",
+					StartSlot:              0,
+					ConfirmationBlockCount: 10,
+				},
+				ChainType:        "Cardano",
+				NetworkMagic:     2,
+				StakingAddresses: stakingAddresses,
+				StakingBridgingAddr: core.StakingBridgingAddresses{
+					StakingBridgingAddr: "addr_test1wpphktxx847q52fzn5g7efu2ftwxzuwwjkgsuvgwn2m7sdgn0z8zg",
+					FeeAddress:          "addr_test1wz4f8kcdy3yue80gq5qmd4902pu8n3wf0k35m54k7g2qmsggfjqck",
+				},
+			},
+			common.ChainIDStrPrime: {
+				BaseCardanoChainConfig: ocCore.BaseCardanoChainConfig{
+					ChainID:                common.ChainIDStrPrime,
+					NetworkAddress:         "localhost:5100",
+					StartBlockHash:         "",
+					StartSlot:              0,
+					ConfirmationBlockCount: 10,
+				},
+				ChainType:        "Cardano",
+				NetworkMagic:     3311,
+				StakingAddresses: stakingAddresses,
+				StakingBridgingAddr: core.StakingBridgingAddresses{
+					StakingBridgingAddr: "addr_test1wrslpa7pfd5qqpk20jvy0sku653yc8sg8lway5k7sssr8ygdefnxh",
+					FeeAddress:          "addr_test1wpg7lpsdaslegalggl4wnjs0qjnc0eh00aw59pgvtzs597cumml62",
+				},
+			},
+		},
+		PullTimeMilis:          1000,
+		DbsPath:                testDir,
+		UsersRewardsPercentage: 0.2,
+		Logger: logger.LoggerConfig{
+			LogFilePath:   filepath.Join(testDir, "staking_logs"),
+			LogLevel:      hclog.Debug,
+			JSONLogFormat: false,
+			AppendFile:    true,
+		},
+	}
+}


### PR DESCRIPTION
Other `apex-bridge` components should be able to invoke some functions of the `staking_component`:
```
- GetExchangeRate(chainID string) (float64, error)
- ChooseStakeAddrForStaking(chainID string, amount *big.Int) (string, error)
- ChooseStakeAddrForUnstaking(chainID string, amount *big.Int) (map[string]*big.Int, error)
- Stake(chainID string, amount *big.Int, stakingAddress string) error
- Unstake(chainID string, amount *big.Int, stakingAddress string) error
- ReceiveReward(chainID string, reward *big.Int, stakingAddress string) error
```

Additoinally, `Exchange Rate` is calculated between total tokens (including rewards) and the total staked tokens across all configured staking addresses.