### PR TITLE
AD-721 Staking address delegation on Oracle

### DIFF
--- a/common/data.go
+++ b/common/data.go
@@ -31,6 +31,7 @@ const (
 	BridgingConfirmedTxType ConfirmedTxType = 0
 	DefundConfirmedTxType   ConfirmedTxType = 1
 	RefundConfirmedTxType   ConfirmedTxType = 2
+	StakeDelConfirmedTxType ConfirmedTxType = 3
 )
 
 var (

--- a/oracle_cardano/utils/validation_utils.go
+++ b/oracle_cardano/utils/validation_utils.go
@@ -10,36 +10,20 @@ import (
 	"github.com/Ethernal-Tech/cardano-infrastructure/wallet"
 )
 
-// Validate if all tx inputs belong to the multisig address or fee address
+// Validate if tx inputs contain the fee address
 func ValidateTxInputs(tx *core.CardanoTx, appConfig *cCore.AppConfig) error {
-	foundBridgingAddress := false
-	foundFeeAddress := false
-
 	chainConfig := appConfig.CardanoChains[tx.OriginChainID]
 	if chainConfig == nil {
 		return fmt.Errorf("unsupported chain id found in tx. chain id: %v", tx.OriginChainID)
 	}
 
 	for _, utxo := range tx.Tx.Inputs {
-		switch utxo.Output.Address {
-		case chainConfig.BridgingAddresses.BridgingAddress:
-			foundBridgingAddress = true
-		case chainConfig.BridgingAddresses.FeeAddress:
-			foundFeeAddress = true
-		default:
-			return fmt.Errorf("unexpected address found in tx input. address: %v", utxo.Output.Address)
+		if utxo.Output.Address == chainConfig.BridgingAddresses.FeeAddress {
+			return nil
 		}
 	}
 
-	if !foundBridgingAddress {
-		return fmt.Errorf("bridging address not found in tx inputs")
-	}
-
-	if !foundFeeAddress {
-		return fmt.Errorf("fee address not found in tx inputs")
-	}
-
-	return nil
+	return fmt.Errorf("fee address not found in tx inputs")
 }
 
 func ValidateOutputsHaveUnknownTokens(tx *core.CardanoTx, appConfig *cCore.AppConfig) error {

--- a/oracle_common/processor/txs_processor/txs_processor.go
+++ b/oracle_common/processor/txs_processor/txs_processor.go
@@ -162,8 +162,9 @@ func (p *TxsProcessorImpl) retrieveTxsForEachBatchFromClaims(
 		filteredTxs := make([]eth.TxDataInfo, 0, len(txs))
 
 		for _, tx := range txs {
-			if tx.ObservedTransactionHash == [32]byte(common.DefundTxHash) {
-				p.logger.Info("Skipping defund tx",
+			if tx.ObservedTransactionHash == [32]byte(common.DefundTxHash) ||
+				tx.TransactionType == uint8(common.StakeDelConfirmedTxType) {
+				p.logger.Info("Skipping defund and stake delegation tx",
 					"chainID", common.ToStrChainID(chainIDInt),
 					"batchID", batchID, "isFailedClaim", isFailedClaim,
 				)


### PR DESCRIPTION
`batch_executed_processor` has different validation logic - only `feeAddress` is mandatory in tx inputs.