### PR TITLE
AD 785 - Reactor Relayer - Should not check is in tx pool when sending to Nexus

### DIFF
--- a/relayer/relayer/evm_chain_operations.go
+++ b/relayer/relayer/evm_chain_operations.go
@@ -65,6 +65,7 @@ func NewEVMChainOperations(
 		ethtxhelper.WithNodeURL(config.NodeURL),
 		ethtxhelper.WithInitClientAndChainIDFn(context.Background()),
 		ethtxhelper.WithDynamicTx(config.DynamicTx),
+		ethtxhelper.WithTxPoolCheck(false),
 		ethtxhelper.WithLogger(logger.Named("tx_helper")))
 
 	evmSmartContract, err := eth.NewEVMGatewaySmartContract(


### PR DESCRIPTION
Nexus relayer shouldnt check if tx is in pool