### PR TITLE
Batcher improvements

### DIFF
--- a/batcher/batcher/batcher_test.go
+++ b/batcher/batcher/batcher_test.go
@@ -422,10 +422,11 @@ type cardanoChainOperationsMock struct {
 // CreateValidatorSetChangeTx implements core.ChainOperations.
 func (c *cardanoChainOperationsMock) CreateValidatorSetChangeTx(ctx context.Context, chainID string,
 	nextBatchID uint64, bridgeSmartContract eth.IBridgeSmartContract,
-	validatorsKeys validatorobserver.ValidatorsPerChain) (*core.GeneratedBatchTxData, error) {
-	args := c.Called(ctx, chainID, nextBatchID, bridgeSmartContract, validatorsKeys)
+	validatorsKeys validatorobserver.ValidatorsPerChain, lastBatchID uint64, lastBatchType uint8,
+) (bool, *core.GeneratedBatchTxData, error) {
+	args := c.Called(ctx, chainID, nextBatchID, bridgeSmartContract, validatorsKeys, lastBatchID, lastBatchType)
 
-	return args.Get(0).(*core.GeneratedBatchTxData), args.Error(1)
+	return args.Get(0).(bool), args.Get(1).(*core.GeneratedBatchTxData), args.Error(2)
 }
 
 var _ core.ChainOperations = (*cardanoChainOperationsMock)(nil)

--- a/batcher/batcher/cardano_chain_operations_test.go
+++ b/batcher/batcher/cardano_chain_operations_test.go
@@ -977,13 +977,13 @@ func Test_CreateValidatorSetChangeTx(t *testing.T) {
 			BlockHash: indexer.Hash{},
 		}, nil)
 
-		generatedData, err := cco.CreateValidatorSetChangeTx(context.TODO(), common.ChainIDStrPrime,
+		_, generatedData, err := cco.CreateValidatorSetChangeTx(context.TODO(), common.ChainIDStrPrime,
 			nextBatchID, bridgeSmartContractMock, validatorobserver.ValidatorsPerChain{
 				common.ChainIDStrPrime: {
 					Keys:       newValidatorChainData,
 					SlotNumber: 0,
 				},
-			})
+			}, 0, 0)
 		require.NoError(t, err)
 
 		if generatedData.BatchType == uint8(ValidatorSetFinal) {

--- a/batcher/core/interfaces.go
+++ b/batcher/core/interfaces.go
@@ -37,7 +37,9 @@ type ChainOperations interface {
 	CreateValidatorSetChangeTx(ctx context.Context,
 		chainID string, nextBatchID uint64,
 		bridgeSmartContract eth.IBridgeSmartContract,
-		validatorsKeys validatorobserver.ValidatorsPerChain) (*GeneratedBatchTxData, error)
+		validatorsKeys validatorobserver.ValidatorsPerChain,
+		lastBatchID uint64, lastBatchType uint8,
+	) (bool, *GeneratedBatchTxData, error)
 }
 
 // ChainSpecificConfig defines the interface for chain-specific configurations

--- a/eth/evm_gateway_smartcontract.go
+++ b/eth/evm_gateway_smartcontract.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	depositGasLimitMultiplier   = 1.7
-	updateVCDGasLimitMultiplier = depositGasLimitMultiplier // potentially set to an different value
+	updateVCDGasLimitMultiplier = depositGasLimitMultiplier // potentially set to a different value
 )
 
 type IEVMGatewaySmartContract interface {

--- a/relayer/relayer/cardano_chain_operations.go
+++ b/relayer/relayer/cardano_chain_operations.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/Ethernal-Tech/apex-bridge/batcher/batcher"
 	cardanotx "github.com/Ethernal-Tech/apex-bridge/cardano"
 	"github.com/Ethernal-Tech/apex-bridge/common"
 	"github.com/Ethernal-Tech/apex-bridge/eth"
@@ -47,6 +48,12 @@ func (cco *CardanoChainOperations) SendTx(
 	ctx context.Context, _ eth.IBridgeSmartContract, smartContractData *eth.ConfirmedBatch,
 ) error {
 	cco.logger.Debug("confirmed batch - sending tx", "batchID", smartContractData.ID, "binary", cco.cardanoCliBinary)
+
+	if smartContractData.BatchType == uint8(batcher.ValidatorSetFinal) {
+		cco.logger.Info("confirmed batch - skipping ValidatorSetFinal batch")
+
+		return nil
+	}
 
 	witnesses := make(
 		[][]byte, len(smartContractData.Signatures)+len(smartContractData.FeeSignatures))

--- a/relayer/relayer/evm_chain_operations.go
+++ b/relayer/relayer/evm_chain_operations.go
@@ -98,6 +98,13 @@ func (cco *EVMChainOperations) SendTx(
 	signature, _ := signatures.Aggregate().Marshal() // error is always nil
 
 	switch batcher.BatchType(smartContractData.BatchType) {
+	case batcher.Normal:
+		cco.logger.Info("Submitting deposit transaction",
+			"signature", hex.EncodeToString(signature),
+			"bitmap", smartContractData.Bitmap,
+			"rawTx", hex.EncodeToString(smartContractData.RawTransaction))
+
+		return cco.evmSmartContract.Deposit(ctx, signature, smartContractData.Bitmap, smartContractData.RawTransaction)
 	case batcher.ValidatorSet:
 		cco.logger.Info("Submitting update validators chain data transaction",
 			"signature", hex.EncodeToString(signature),
@@ -106,13 +113,10 @@ func (cco *EVMChainOperations) SendTx(
 
 		return cco.evmSmartContract.UpdateValidatorsChainData(ctx,
 			signature, smartContractData.Bitmap, smartContractData.RawTransaction)
-	case batcher.Normal:
-		cco.logger.Info("Submitting deposit transaction",
-			"signature", hex.EncodeToString(signature),
-			"bitmap", smartContractData.Bitmap,
-			"rawTx", hex.EncodeToString(smartContractData.RawTransaction))
+	case batcher.ValidatorSetFinal:
+		cco.logger.Info("Skipping ValidatorSetFinal batch")
 
-		return cco.evmSmartContract.Deposit(ctx, signature, smartContractData.Bitmap, smartContractData.RawTransaction)
+		return nil
 	default:
 		return fmt.Errorf("invalid batch type: %d", smartContractData.BatchType)
 	}

--- a/relayer/relayer/evm_chain_operations_test.go
+++ b/relayer/relayer/evm_chain_operations_test.go
@@ -162,7 +162,7 @@ func TestEVMChainOperations(t *testing.T) {
 				BatchType: uint8(batcher.ValidatorSetFinal),
 			})
 
-			require.Error(t, err)
+			require.NoError(t, err)
 
 			gateway.AssertNotCalled(t, "Deposit",
 				mock.Anything,


### PR DESCRIPTION
This PR does some improvements in the code:

1. Do not log error when status of VSC batch is pending on evm chain
2. Force resend VSC batch on evm chain if previous batch is failed
3. Do not send VS final batch to Cardano chain
4. Do not update batch txs state for VSC batch
5. Some clean up and removal of obsolete code