### PR TITLE
Multiple bridging addresses fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,6 +503,14 @@ $ apex-bridge bridge-admin delegate-address-to-stake-pool \
 ```
 - instead of `--key` it is possible to set key secret manager configuration file with `--key-config /path/config.json`.
 
+```shell
+$ apex-bridge bridge-admin redistribute-bridging-addresses-tokens \
+        --bridge-url http://localhost:12001 \
+        --chain prime \
+        --key 922769e22b70614d4172fc899126785841f4de7d7c009fc338923ce50683023d
+```
+- instead of `--key` it is possible to set key secret manager configuration file with `--key-config /path/config.json`.
+
 # How to get bridge and gateway smart contract version
 ```shell
 apex-bridge sc-version \

--- a/bridging_addresses_coordinator/bridging_addresses_coordinator.go
+++ b/bridging_addresses_coordinator/bridging_addresses_coordinator.go
@@ -351,9 +351,14 @@ func (c *BridgingAddressesCoordinatorImpl) processNativeTokens(
 
 		requiredTokenAmounts[tokenName] -= tokensTakenFromAddress
 		addrAmount.includeInTx[tokenName] = tokensTakenFromAddress
+		addrAmount.totalTokenAmounts[tokenName] -= tokensTakenFromAddress
 
 		if requiredTokenAmounts[tokenName] == 0 {
 			delete(requiredTokenAmounts, tokenName)
+		}
+
+		if addrAmount.totalTokenAmounts[tokenName] == 0 {
+			delete(addrAmount.totalTokenAmounts, tokenName)
 		}
 	}
 }

--- a/cli/deploy-evm/deploy_contract_params.go
+++ b/cli/deploy-evm/deploy_contract_params.go
@@ -206,7 +206,7 @@ func (ip *deployContractParams) Execute(
 		return nil, err
 	}
 
-	wallet, err := eth.GetEthWalletForBladeAdmin(true, ip.evmPrivateKey, ip.privateKeyConfig)
+	wallet, err := eth.GetEthWalletForBladeAdmin(false, ip.evmPrivateKey, ip.privateKeyConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create smart contracts admin wallet: %w", err)
 	}


### PR DESCRIPTION
- Deploy smart contract command loads Blade Admin's key secret manager configuration file.
- Redistribute tokens command added to `README` file.
- Bug fix of cooridnator's address processing where we were unable to send all native and currency tokens at the same time from the addresses (send everything)