### PR TITLE
Bugfix for GetProcessed after GetPending

### DIFF
--- a/oracle_cardano/core/interfaces.go
+++ b/oracle_cardano/core/interfaces.go
@@ -17,6 +17,7 @@ type CardanoTxsDB interface {
 	GetUnprocessedTxs(chainID string, priority uint8, threshold int) ([]*CardanoTx, error)
 	GetAllUnprocessedTxs(chainID string, threshold int) ([]*CardanoTx, error)
 	GetPendingTx(entityID cCore.DBTxID) (cCore.BaseTx, error)
+	GetGenericProcessedTx(entityID cCore.DBTxID) (cCore.BaseTx, error)
 	GetProcessedTx(entityID cCore.DBTxID) (*ProcessedCardanoTx, error)
 	GetUnprocessedBatchEvents(chainID string) ([]*cCore.DBBatchInfoEvent, error)
 	AddTxs(processedTxs []*ProcessedCardanoTx, unprocessedTxs []*CardanoTx) error

--- a/oracle_cardano/core/test_mocks.go
+++ b/oracle_cardano/core/test_mocks.go
@@ -171,6 +171,18 @@ func (m *CardanoTxsProcessorDBMock) GetPendingTx(entityID cCore.DBTxID) (cCore.B
 	return nil, args.Error(1)
 }
 
+// GetGenericProcessedTx implements CardanoTxsProcessorDB.
+func (m *CardanoTxsProcessorDBMock) GetGenericProcessedTx(entityID cCore.DBTxID) (cCore.BaseTx, error) {
+	args := m.Called(entityID)
+	if args.Get(0) != nil {
+		arg0, _ := args.Get(0).(cCore.BaseTx)
+
+		return arg0, args.Error(1)
+	}
+
+	return nil, args.Error(1)
+}
+
 // GetProcessedTx implements CardanoTxsProcessorDB.
 func (m *CardanoTxsProcessorDBMock) GetProcessedTx(
 	entityID cCore.DBTxID,

--- a/oracle_cardano/processor/txs_processor/cardano_state_processor.go
+++ b/oracle_cardano/processor/txs_processor/cardano_state_processor.go
@@ -262,13 +262,13 @@ func (sp *CardanoStateProcessor) getTxsFromBatchEvent(
 		}
 
 		// pending returned error — check if it's present in processed
-		processedTx, errProcessed := sp.db.GetProcessedTx(
+		_, errProcessed := sp.db.GetGenericProcessedTx(
 			cCore.DBTxID{
 				ChainID: common.ToStrChainID(hash.SourceChainID),
 				DBKey:   hash.ObservedTransactionHash[:],
 			},
 		)
-		if processedTx == nil || errProcessed != nil {
+		if errProcessed != nil {
 			sp.logger.Error("Failed to get proccessed tx", "err", errProcessed)
 			// not in processed either — return original pending error
 			return nil, errPending

--- a/oracle_common/database_access/bbolt.go
+++ b/oracle_common/database_access/bbolt.go
@@ -112,6 +112,26 @@ func (bd *BBoltDBBase[TTx, TProcessedTx, TExpectedTx]) GetPendingTx(
 	return result, err
 }
 
+func (bd *BBoltDBBase[TTx, TProcessedTx, TExpectedTx]) GetGenericProcessedTx(
+	entityID core.DBTxID,
+) (result core.BaseTx, err error) {
+	err = bd.DB.View(func(tx *bbolt.Tx) (err error) {
+		data := tx.Bucket(ChainBucket(ProcessedTxsBucket, entityID.ChainID)).Get(entityID.DBKey)
+		if len(data) == 0 {
+			return fmt.Errorf("couldn't get processed tx for entityID: %v", entityID)
+		}
+
+		result, err = common.GetRegisteredTypeInstance[core.BaseTx](bd.TypeRegister, entityID.ChainID)
+		if err != nil {
+			return err
+		}
+
+		return json.Unmarshal(data, &result)
+	})
+
+	return result, err
+}
+
 func (bd *BBoltDBBase[TTx, TProcessedTx, TExpectedTx]) GetProcessedTx(
 	entityID core.DBTxID,
 ) (result TProcessedTx, err error) {

--- a/oracle_eth/core/interfaces.go
+++ b/oracle_eth/core/interfaces.go
@@ -17,6 +17,7 @@ type EthTxsDB interface {
 	GetUnprocessedTxs(chainID string, priority uint8, threshold int) ([]*EthTx, error)
 	GetAllUnprocessedTxs(chainID string, threshold int) ([]*EthTx, error)
 	GetPendingTx(entityID oCore.DBTxID) (oCore.BaseTx, error)
+	GetGenericProcessedTx(entityID oCore.DBTxID) (oCore.BaseTx, error)
 	GetProcessedTx(entityID oCore.DBTxID) (*ProcessedEthTx, error)
 	GetProcessedTxByInnerActionTxHash(chainID string, innerActionTxHash []byte) (*ProcessedEthTx, error)
 	ClearAllTxs(chainID string) error

--- a/oracle_eth/core/test_mocks.go
+++ b/oracle_eth/core/test_mocks.go
@@ -158,6 +158,18 @@ func (m *EthTxsProcessorDBMock) GetPendingTx(entityID oCore.DBTxID) (oCore.BaseT
 	return nil, args.Error(1)
 }
 
+// GetGenericProcessedTx implements EthTxsProcessorDB.
+func (m *EthTxsProcessorDBMock) GetGenericProcessedTx(entityID oCore.DBTxID) (oCore.BaseTx, error) {
+	args := m.Called(entityID)
+	if args.Get(0) != nil {
+		arg0, _ := args.Get(0).(oCore.BaseTx)
+
+		return arg0, args.Error(1)
+	}
+
+	return nil, args.Error(1)
+}
+
 // GetProcessedTx implements EthTxsProcessorDB.
 func (m *EthTxsProcessorDBMock) GetProcessedTx(
 	entityID oCore.DBTxID,

--- a/oracle_eth/processor/txs_processor/eth_state_processor.go
+++ b/oracle_eth/processor/txs_processor/eth_state_processor.go
@@ -265,13 +265,13 @@ func (sp *EthStateProcessor) getTxsFromBatchEvent(
 		}
 
 		// pending returned error — check if it's present in processed
-		processedTx, errProcessed := sp.db.GetProcessedTx(
+		_, errProcessed := sp.db.GetGenericProcessedTx(
 			oracleCore.DBTxID{
 				ChainID: common.ToStrChainID(hash.SourceChainID),
 				DBKey:   hash.ObservedTransactionHash[:],
 			},
 		)
-		if processedTx == nil || errProcessed != nil {
+		if errProcessed != nil {
 			sp.logger.Error("Failed to get proccessed tx", "err", errProcessed)
 			// not in processed either — return original pending error
 			return nil, errPending


### PR DESCRIPTION
GetPending doesnt care if the pending tx is eth or cardano tx. GetProcessed did care about that, so we add a new method that also doesnt care