### PR TITLE
Improve oracle protocol params handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,8 @@ $ apex-bridge generate-configs evm-chain \
         --evm-block-rounding-threshold <block rounding threshold> \
         --evm-starting-block <block number> \
         --evm-num-block-confirmations <num> \
+        --evm-poll-interval <how often a tracker polls the rpc for new blocks - uint64 in milliseconds> \
+        --evm-sync-batch-size <batch size of blocks for tracker to fetch at a time> \
         --evm-min-fee-for-bridging <minimal bridging fee> \
         --min-operation-fee <minimal operation fee> \
         --evm-relayer-gas-fee-multiplier <gas fee multiplier for evm relayer> \

--- a/oracle_cardano/processor/tx_processors/success/bridging_requested_processor_skyline.go
+++ b/oracle_cardano/processor/tx_processors/success/bridging_requested_processor_skyline.go
@@ -605,7 +605,9 @@ func (p *BridgingRequestedProcessorSkylineImpl) calculateMinUtxo(
 		return 0, fmt.Errorf("chain info not found for chainID: %s", config.ChainID)
 	}
 
-	builder.SetProtocolParameters(chainInfo.ProtocolParams)
+	protocolParams := chainInfo.GetProtocolParams()
+
+	builder.SetProtocolParameters(protocolParams)
 
 	tokenAmounts := make([]cardanowallet.TokenAmount, 0, len(nativeTokensSum))
 

--- a/oracle_cardano/processor/tx_processors/success/bridging_requested_processor_skyline_test.go
+++ b/oracle_cardano/processor/tx_processors/success/bridging_requested_processor_skyline_test.go
@@ -1,12 +1,14 @@
 package successtxprocessors
 
 import (
+	"context"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"math/big"
 	"strings"
 	"testing"
+	"time"
 
 	brAddrManager "github.com/Ethernal-Tech/apex-bridge/bridging_addresses_manager"
 	cardanotx "github.com/Ethernal-Tech/apex-bridge/cardano"
@@ -187,9 +189,17 @@ func TestBridgingRequestedProcessorSkyline(t *testing.T) {
 		return appConfig
 	}
 
-	chainInfos := map[string]*cChain.CardanoChainInfo{
-		common.ChainIDStrPrime:   {ProtocolParams: protocolParameters},
-		common.ChainIDStrCardano: {ProtocolParams: protocolParameters},
+	chainInfos := make(map[string]*cChain.CardanoChainInfo)
+
+	for _, cc := range getAppConfig(false).CardanoChains {
+		cc.OgmiosURL = mockOgmiosURL
+
+		db := &cCore.ProtocolParamsDBMock{Params: protocolParameters, ExpiresAt: time.Now().UTC().Add(time.Hour)}
+
+		info, err := cChain.NewCardanoChainInfo(context.Background(), cc, db, hclog.NewNullLogger())
+		require.NoError(t, err)
+
+		chainInfos[cc.ChainID] = info
 	}
 
 	t.Run("ValidateAndAddClaim empty tx", func(t *testing.T) {

--- a/oracle_cardano/processor/tx_processors/success/refund_request_processor.go
+++ b/oracle_cardano/processor/tx_processors/success/refund_request_processor.go
@@ -216,7 +216,9 @@ func calculateMinUtxoForRefund(
 		return 0, fmt.Errorf("chain info for chainID: %s, not found", config.ChainID)
 	}
 
-	builder.SetProtocolParameters(chainInfo.ProtocolParams)
+	protocolParams := chainInfo.GetProtocolParams()
+
+	builder.SetProtocolParameters(protocolParams)
 
 	tokenNameToAmount := make(map[string]uint64)
 

--- a/oracle_cardano/processor/tx_processors/success/refund_request_processor_skyline_test.go
+++ b/oracle_cardano/processor/tx_processors/success/refund_request_processor_skyline_test.go
@@ -1,10 +1,12 @@
 package successtxprocessors
 
 import (
+	"context"
 	"encoding/hex"
 	"fmt"
 	"math/big"
 	"testing"
+	"time"
 
 	brAddrManager "github.com/Ethernal-Tech/apex-bridge/bridging_addresses_manager"
 	cardanotx "github.com/Ethernal-Tech/apex-bridge/cardano"
@@ -126,9 +128,12 @@ func TestSkylineRefundRequestedProcessor(t *testing.T) {
 		chainInfos := make(map[string]*cChain.CardanoChainInfo, len(appConfig.CardanoChains))
 
 		for _, cc := range appConfig.CardanoChains {
-			info := cChain.NewCardanoChainInfo(cc)
+			cc.OgmiosURL = mockOgmiosURL
 
-			info.ProtocolParams = protocolParameters
+			db := &cCore.ProtocolParamsDBMock{Params: protocolParameters, ExpiresAt: time.Now().UTC().Add(time.Hour)}
+
+			info, err := cChain.NewCardanoChainInfo(context.Background(), cc, db, hclog.NewNullLogger())
+			require.NoError(t, err)
 
 			chainInfos[cc.ChainID] = info
 		}

--- a/oracle_cardano/processor/tx_processors/success/refund_request_processor_test.go
+++ b/oracle_cardano/processor/tx_processors/success/refund_request_processor_test.go
@@ -1,9 +1,11 @@
 package successtxprocessors
 
 import (
+	"context"
 	"fmt"
 	"math/big"
 	"testing"
+	"time"
 
 	brAddrManager "github.com/Ethernal-Tech/apex-bridge/bridging_addresses_manager"
 	cardanotx "github.com/Ethernal-Tech/apex-bridge/cardano"
@@ -17,6 +19,8 @@ import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/require"
 )
+
+const mockOgmiosURL = "http://ogmios.mock" // never contacted: params are pre-seeded and fresh
 
 var (
 	protocolParameters = []byte(`{"costModels":{"PlutusV1":[197209,0,1,1,396231,621,0,1,150000,1000,0,1,150000,32,2477736,29175,4,29773,100,29773,100,29773,100,29773,100,29773,100,29773,100,100,100,29773,100,150000,32,150000,32,150000,32,150000,1000,0,1,150000,32,150000,1000,0,8,148000,425507,118,0,1,1,150000,1000,0,8,150000,112536,247,1,150000,10000,1,136542,1326,1,1000,150000,1000,1,150000,32,150000,32,150000,32,1,1,150000,1,150000,4,103599,248,1,103599,248,1,145276,1366,1,179690,497,1,150000,32,150000,32,150000,32,150000,32,150000,32,150000,32,148000,425507,118,0,1,1,61516,11218,0,1,150000,32,148000,425507,118,0,1,1,148000,425507,118,0,1,1,2477736,29175,4,0,82363,4,150000,5000,0,1,150000,32,197209,0,1,1,150000,32,150000,32,150000,32,150000,32,150000,32,150000,32,150000,32,3345831,1,1],"PlutusV2":[205665,812,1,1,1000,571,0,1,1000,24177,4,1,1000,32,117366,10475,4,23000,100,23000,100,23000,100,23000,100,23000,100,23000,100,100,100,23000,100,19537,32,175354,32,46417,4,221973,511,0,1,89141,32,497525,14068,4,2,196500,453240,220,0,1,1,1000,28662,4,2,245000,216773,62,1,1060367,12586,1,208512,421,1,187000,1000,52998,1,80436,32,43249,32,1000,32,80556,1,57667,4,1000,10,197145,156,1,197145,156,1,204924,473,1,208896,511,1,52467,32,64832,32,65493,32,22558,32,16563,32,76511,32,196500,453240,220,0,1,1,69522,11687,0,1,60091,32,196500,453240,220,0,1,1,196500,453240,220,0,1,1,1159724,392670,0,2,806990,30482,4,1927926,82523,4,265318,0,4,0,85931,32,205665,812,1,1,41182,32,212342,32,31220,32,32696,32,43357,32,32247,32,38314,32,35892428,10,9462713,1021,10,38887044,32947,10]},"protocolVersion":{"major":7,"minor":0},"maxBlockHeaderSize":1100,"maxBlockBodySize":65536,"maxTxSize":16384,"txFeeFixed":155381,"txFeePerByte":44,"stakeAddressDeposit":0,"stakePoolDeposit":0,"minPoolCost":0,"poolRetireMaxEpoch":18,"stakePoolTargetNum":100,"poolPledgeInfluence":0,"monetaryExpansion":0.1,"treasuryCut":0.1,"collateralPercentage":150,"executionUnitPrices":{"priceMemory":0.0577,"priceSteps":0.0000721},"utxoCostPerByte":4310,"maxTxExecutionUnits":{"memory":16000000,"steps":10000000000},"maxBlockExecutionUnits":{"memory":80000000,"steps":40000000000},"maxCollateralInputs":3,"maxValueSize":5000,"extraPraosEntropy":null,"decentralization":null,"minUTxOValue":null}`)
@@ -83,9 +87,12 @@ func TestRefundRequestedProcessor(t *testing.T) {
 		chainInfos := make(map[string]*cChain.CardanoChainInfo, len(appConfig.CardanoChains))
 
 		for _, cc := range appConfig.CardanoChains {
-			info := cChain.NewCardanoChainInfo(cc)
+			cc.OgmiosURL = mockOgmiosURL
 
-			info.ProtocolParams = protocolParameters
+			db := &cCore.ProtocolParamsDBMock{Params: protocolParameters, ExpiresAt: time.Now().UTC().Add(time.Hour)}
+
+			info, err := cChain.NewCardanoChainInfo(context.Background(), cc, db, hclog.NewNullLogger())
+			require.NoError(t, err)
 
 			chainInfos[cc.ChainID] = info
 		}

--- a/oracle_common/chain/cardano_chain_info.go
+++ b/oracle_common/chain/cardano_chain_info.go
@@ -2,39 +2,179 @@ package chain
 
 import (
 	"context"
+	"fmt"
+	"sync"
+	"time"
 
+	"github.com/Ethernal-Tech/apex-bridge/common"
 	cCore "github.com/Ethernal-Tech/apex-bridge/oracle_common/core"
-	infracommon "github.com/Ethernal-Tech/cardano-infrastructure/common"
+	"github.com/Ethernal-Tech/cardano-infrastructure/wallet"
+	"github.com/hashicorp/go-hclog"
+)
+
+const (
+	protocolParamsTTL     = 30 * time.Minute
+	populateRetryInterval = 5 * time.Second
 )
 
 type CardanoChainInfo struct {
-	Config *cCore.CardanoChainConfig
+	config *cCore.CardanoChainConfig
 
-	ProtocolParams []byte
+	ctx        context.Context
+	db         cCore.ProtocolParamsDB
+	logger     hclog.Logger
+	txProvider wallet.ITxProvider
+
+	lock sync.Mutex
 }
 
-func NewCardanoChainInfo(config *cCore.CardanoChainConfig) *CardanoChainInfo {
-	return &CardanoChainInfo{
-		Config: config,
+func NewCardanoChainInfo(
+	ctx context.Context, config *cCore.CardanoChainConfig,
+	db cCore.ProtocolParamsDB, logger hclog.Logger,
+) (*CardanoChainInfo, error) {
+	txProvider, err := config.CreateTxProvider()
+	if err != nil {
+		return nil, err
 	}
+
+	info := &CardanoChainInfo{
+		config:     config,
+		ctx:        ctx,
+		db:         db,
+		logger:     logger,
+		txProvider: txProvider,
+	}
+
+	if err := info.initialize(); err != nil {
+		return nil, err
+	}
+
+	return info, nil
 }
 
-func (info *CardanoChainInfo) Populate(ctx context.Context) error {
-	txProvider, err := info.Config.CreateTxProvider()
+func (info *CardanoChainInfo) initialize() error {
+	info.logger.Debug("getting protocol params from db", "chainID", info.config.ChainID)
+
+	persisted, expiresAt, err := info.db.GetProtocolParams(info.config.ChainID)
 	if err != nil {
-		return err
+		return fmt.Errorf(
+			"failed to read protocol parameters from the database for chain %s. err: %w", info.config.ChainID, err)
 	}
 
-	protocolParams, err := infracommon.ExecuteWithRetry(
-		ctx, func(ctx context.Context) ([]byte, error) {
-			return txProvider.GetProtocolParameters(ctx)
-		},
-	)
-	if err != nil {
-		return err
+	if len(persisted) > 0 {
+		info.logger.Debug("db contains protocol params", "chainID", info.config.ChainID)
+
+		if time.Now().UTC().Before(expiresAt) {
+			return nil
+		}
+
+		info.logger.Debug("db protocol params stale. trying to fetch fresh",
+			"chainID", info.config.ChainID, "expiresAt", expiresAt)
+
+		pp, err := info.txProvider.GetProtocolParameters(info.ctx)
+		if err != nil {
+			if common.IsContextDoneErr(err) {
+				return err
+			} else {
+				info.logger.Error("failed to fetch protocol parameters", "chainID", info.config.ChainID, "err", err)
+
+				return nil
+			}
+		}
+
+		newExpiresAt := time.Now().UTC().Add(protocolParamsTTL)
+
+		info.logger.Debug("saving fresh protocol params to db", "chainID", info.config.ChainID, "newExpiresAt", newExpiresAt)
+
+		if err := info.db.SaveProtocolParams(
+			info.config.ChainID, pp, newExpiresAt); err != nil {
+			info.logger.Error("failed to persist protocol parameters",
+				"chainID", info.config.ChainID, "err", err)
+		}
+
+		return nil
 	}
 
-	info.ProtocolParams = protocolParams
+	if err := info.ensureProtocolParamsPersisted(); err != nil {
+		return fmt.Errorf("failed to ensure protocol parameters for chain %s. err: %w", info.config.ChainID, err)
+	}
 
 	return nil
+}
+
+func (info *CardanoChainInfo) GetProtocolParams() []byte {
+	info.lock.Lock()
+	defer info.lock.Unlock()
+
+	info.logger.Debug("getting protocol params from db", "chainID", info.config.ChainID)
+
+	persisted, expiresAt, err := info.db.GetProtocolParams(info.config.ChainID)
+	if err != nil || len(persisted) == 0 {
+		info.logger.Error("failed to read protocol parameters from the database",
+			"chainID", info.config.ChainID, "err", err)
+
+		if err = info.ensureProtocolParamsPersisted(); err != nil {
+			return []byte{}
+		}
+
+		persisted, _, err = info.db.GetProtocolParams(info.config.ChainID)
+		if err != nil {
+			info.logger.Error("failed to read protocol parameters from the database after ensuring they are persisted",
+				"chainID", info.config.ChainID, "err", err)
+
+			return []byte{}
+		}
+
+		return persisted
+	}
+
+	if time.Now().UTC().Before(expiresAt) {
+		return persisted
+	}
+
+	info.logger.Debug("db protocol params stale. trying to fetch fresh",
+		"chainID", info.config.ChainID, "expiresAt", expiresAt)
+
+	pp, err := info.txProvider.GetProtocolParameters(info.ctx)
+	if err != nil {
+		info.logger.Error("failed to fetch protocol parameters",
+			"chainID", info.config.ChainID, "err", err)
+
+		return persisted
+	}
+
+	newExpiresAt := time.Now().UTC().Add(protocolParamsTTL)
+
+	info.logger.Debug("saving fresh protocol params to db", "chainID", info.config.ChainID, "newExpiresAt", newExpiresAt)
+
+	if err := info.db.SaveProtocolParams(
+		info.config.ChainID, pp, newExpiresAt); err != nil {
+		info.logger.Error("failed to persist protocol parameters",
+			"chainID", info.config.ChainID, "err", err)
+	}
+
+	return pp
+}
+
+func (info *CardanoChainInfo) ensureProtocolParamsPersisted() error {
+	return common.RetryForever(info.ctx, populateRetryInterval, func(ctx context.Context) error {
+		info.logger.Debug("ensuring db protocol params - fetching", "chainID", info.config.ChainID)
+
+		pp, err := info.txProvider.GetProtocolParameters(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to fetch protocol parameters for chain %s. err: %w", info.config.ChainID, err)
+		}
+
+		newExpiresAt := time.Now().UTC().Add(protocolParamsTTL)
+
+		info.logger.Debug("ensuring db protocol params - persisting",
+			"chainID", info.config.ChainID, "newExpiresAt", newExpiresAt)
+
+		if err := info.db.SaveProtocolParams(
+			info.config.ChainID, pp, newExpiresAt); err != nil {
+			return fmt.Errorf("failed to persist protocol parameters for chain %s. err: %w", info.config.ChainID, err)
+		}
+
+		return nil
+	})
 }

--- a/oracle_common/chain/cardano_chain_info_test.go
+++ b/oracle_common/chain/cardano_chain_info_test.go
@@ -1,0 +1,256 @@
+package chain
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	cardanotx "github.com/Ethernal-Tech/apex-bridge/cardano"
+	cCore "github.com/Ethernal-Tech/apex-bridge/oracle_common/core"
+	"github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	paramsFromChain = []byte("protocol-params-fetched-from-chain")
+	paramsFreshInDB = []byte("fresh-protocol-params-in-db")
+	paramsStaleInDB = []byte("stale-protocol-params-in-db")
+)
+
+func newTestChainInfo(
+	ctx context.Context, db *cCore.ProtocolParamsDBMock, txProvider *cardanotx.TxProviderTestMock,
+) *CardanoChainInfo {
+	return &CardanoChainInfo{
+		config:     &cCore.CardanoChainConfig{ChainID: "prime"},
+		ctx:        ctx,
+		db:         db,
+		logger:     hclog.NewNullLogger(),
+		txProvider: txProvider,
+	}
+}
+
+func freshExpiry() time.Time { return time.Now().UTC().Add(time.Hour) }
+func staleExpiry() time.Time { return time.Now().UTC().Add(-time.Hour) }
+
+func TestCardanoChainInfo_initialize(t *testing.T) {
+	t.Run("db has fresh params - uses them without touching the chain", func(t *testing.T) {
+		expiry := freshExpiry()
+		db := &cCore.ProtocolParamsDBMock{Params: paramsFreshInDB, ExpiresAt: expiry}
+		txProvider := &cardanotx.TxProviderTestMock{}
+
+		info := newTestChainInfo(context.Background(), db, txProvider)
+
+		require.NoError(t, info.initialize())
+
+		txProvider.AssertNotCalled(t, "GetProtocolParameters")
+		require.Equal(t, paramsFreshInDB, db.Params)
+		require.Equal(t, expiry, db.ExpiresAt)
+	})
+
+	t.Run("db has stale params and fetch succeeds - refreshes and persists", func(t *testing.T) {
+		db := &cCore.ProtocolParamsDBMock{Params: paramsStaleInDB, ExpiresAt: staleExpiry()}
+		txProvider := &cardanotx.TxProviderTestMock{}
+		txProvider.On("GetProtocolParameters", mock.Anything).Return(paramsFromChain, nil).Once()
+
+		info := newTestChainInfo(context.Background(), db, txProvider)
+
+		require.NoError(t, info.initialize())
+
+		txProvider.AssertExpectations(t)
+		require.Equal(t, paramsFromChain, db.Params)
+		require.True(t, db.ExpiresAt.After(time.Now().UTC()))
+	})
+
+	t.Run("db has stale params and fetch fails - keeps stale params and continues", func(t *testing.T) {
+		staleAt := staleExpiry()
+		db := &cCore.ProtocolParamsDBMock{Params: paramsStaleInDB, ExpiresAt: staleAt}
+		txProvider := &cardanotx.TxProviderTestMock{}
+		txProvider.On("GetProtocolParameters", mock.Anything).Return(nil, errors.New("chain unreachable")).Once()
+
+		info := newTestChainInfo(context.Background(), db, txProvider)
+
+		// startup is not aborted by a failed refresh - the stale params are left untouched
+		require.NoError(t, info.initialize())
+
+		txProvider.AssertExpectations(t)
+		require.Equal(t, paramsStaleInDB, db.Params)
+		require.Equal(t, staleAt, db.ExpiresAt)
+	})
+
+	t.Run("db has stale params and context is done during refresh - returns error", func(t *testing.T) {
+		staleAt := staleExpiry()
+		db := &cCore.ProtocolParamsDBMock{Params: paramsStaleInDB, ExpiresAt: staleAt}
+		txProvider := &cardanotx.TxProviderTestMock{}
+		txProvider.On("GetProtocolParameters", mock.Anything).Return(nil, context.Canceled).Once()
+
+		info := newTestChainInfo(context.Background(), db, txProvider)
+
+		require.ErrorIs(t, info.initialize(), context.Canceled)
+		require.Equal(t, paramsStaleInDB, db.Params)
+		require.Equal(t, staleAt, db.ExpiresAt)
+	})
+
+	t.Run("db is empty and fetch succeeds - persists fetched params", func(t *testing.T) {
+		db := &cCore.ProtocolParamsDBMock{}
+		txProvider := &cardanotx.TxProviderTestMock{}
+		txProvider.On("GetProtocolParameters", mock.Anything).Return(paramsFromChain, nil).Once()
+
+		info := newTestChainInfo(context.Background(), db, txProvider)
+
+		require.NoError(t, info.initialize())
+
+		txProvider.AssertExpectations(t)
+		require.Equal(t, paramsFromChain, db.Params)
+		require.True(t, db.ExpiresAt.After(time.Now().UTC()))
+	})
+
+	t.Run("db is empty and fetch fails - keeps retrying, bounded only by the context", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+
+		db := &cCore.ProtocolParamsDBMock{}
+		txProvider := &cardanotx.TxProviderTestMock{}
+		// cancel on the first attempt so the retry-forever loop exits instead of blocking
+		txProvider.On("GetProtocolParameters", mock.Anything).
+			Run(func(mock.Arguments) { cancel() }).
+			Return(nil, errors.New("chain unreachable"))
+
+		info := newTestChainInfo(ctx, db, txProvider)
+
+		require.Error(t, info.initialize())
+		txProvider.AssertCalled(t, "GetProtocolParameters", mock.Anything)
+		require.Empty(t, db.Params)
+	})
+
+	t.Run("db is empty and persisting fails - does not silently succeed", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+
+		// fetch works but the db write fails: this must be retried, never treated as success
+		db := &cCore.ProtocolParamsDBMock{SaveErr: errors.New("db write failed")}
+		txProvider := &cardanotx.TxProviderTestMock{}
+		txProvider.On("GetProtocolParameters", mock.Anything).
+			Run(func(mock.Arguments) { cancel() }).
+			Return(paramsFromChain, nil)
+
+		info := newTestChainInfo(ctx, db, txProvider)
+
+		require.Error(t, info.initialize())
+		txProvider.AssertCalled(t, "GetProtocolParameters", mock.Anything)
+		require.Empty(t, db.Params)
+	})
+
+	t.Run("db read fails - returns error", func(t *testing.T) {
+		db := &cCore.ProtocolParamsDBMock{GetErr: errors.New("db read failed")}
+		txProvider := &cardanotx.TxProviderTestMock{}
+
+		info := newTestChainInfo(context.Background(), db, txProvider)
+
+		require.Error(t, info.initialize())
+		txProvider.AssertNotCalled(t, "GetProtocolParameters")
+	})
+}
+
+func TestCardanoChainInfo_GetProtocolParams(t *testing.T) {
+	t.Run("db has fresh params - returns them without touching the chain", func(t *testing.T) {
+		db := &cCore.ProtocolParamsDBMock{Params: paramsFreshInDB, ExpiresAt: freshExpiry()}
+		txProvider := &cardanotx.TxProviderTestMock{}
+
+		info := newTestChainInfo(context.Background(), db, txProvider)
+
+		require.Equal(t, paramsFreshInDB, info.GetProtocolParams())
+		txProvider.AssertNotCalled(t, "GetProtocolParameters")
+	})
+
+	t.Run("db has stale params and fetch succeeds - refreshes, persists and returns fresh", func(t *testing.T) {
+		db := &cCore.ProtocolParamsDBMock{Params: paramsStaleInDB, ExpiresAt: staleExpiry()}
+		txProvider := &cardanotx.TxProviderTestMock{}
+		txProvider.On("GetProtocolParameters", mock.Anything).Return(paramsFromChain, nil).Once()
+
+		info := newTestChainInfo(context.Background(), db, txProvider)
+
+		require.Equal(t, paramsFromChain, info.GetProtocolParams())
+		txProvider.AssertExpectations(t)
+		require.Equal(t, paramsFromChain, db.Params)
+		require.True(t, db.ExpiresAt.After(time.Now().UTC()))
+	})
+
+	t.Run("db has stale params and fetch fails - returns stale params without error", func(t *testing.T) {
+		staleAt := staleExpiry()
+		db := &cCore.ProtocolParamsDBMock{Params: paramsStaleInDB, ExpiresAt: staleAt}
+		txProvider := &cardanotx.TxProviderTestMock{}
+		txProvider.On("GetProtocolParameters", mock.Anything).Return(nil, errors.New("chain unreachable")).Once()
+
+		info := newTestChainInfo(context.Background(), db, txProvider)
+
+		require.Equal(t, paramsStaleInDB, info.GetProtocolParams())
+		txProvider.AssertExpectations(t)
+		require.Equal(t, paramsStaleInDB, db.Params)
+		require.Equal(t, staleAt, db.ExpiresAt)
+	})
+
+	t.Run("db is unexpectedly empty - fetches, persists and returns", func(t *testing.T) {
+		db := &cCore.ProtocolParamsDBMock{}
+		txProvider := &cardanotx.TxProviderTestMock{}
+		txProvider.On("GetProtocolParameters", mock.Anything).Return(paramsFromChain, nil).Once()
+
+		info := newTestChainInfo(context.Background(), db, txProvider)
+
+		require.Equal(t, paramsFromChain, info.GetProtocolParams())
+		txProvider.AssertExpectations(t)
+		require.Equal(t, paramsFromChain, db.Params)
+	})
+
+	t.Run("db read fails persistently - returns empty without error", func(t *testing.T) {
+		// even with a completely broken db, the processors must get a value, never an error
+		db := &cCore.ProtocolParamsDBMock{GetErr: errors.New("db read failed")}
+		txProvider := &cardanotx.TxProviderTestMock{}
+		txProvider.On("GetProtocolParameters", mock.Anything).Return(paramsFromChain, nil).Once()
+
+		info := newTestChainInfo(context.Background(), db, txProvider)
+
+		require.Empty(t, info.GetProtocolParams())
+	})
+
+	t.Run("concurrent callers are serialized and all get valid params", func(t *testing.T) {
+		db := &cCore.ProtocolParamsDBMock{Params: paramsStaleInDB, ExpiresAt: staleExpiry()}
+		txProvider := &cardanotx.TxProviderTestMock{}
+		txProvider.On("GetProtocolParameters", mock.Anything).Return(paramsFromChain, nil)
+
+		info := newTestChainInfo(context.Background(), db, txProvider)
+
+		const callers = 20
+
+		var (
+			wg      sync.WaitGroup
+			results = make([][]byte, callers)
+		)
+
+		wg.Add(callers)
+
+		for i := range results {
+			go func(idx int) {
+				defer wg.Done()
+
+				results[idx] = info.GetProtocolParams()
+			}(i)
+		}
+
+		wg.Wait()
+
+		for _, res := range results {
+			require.Equal(t, paramsFromChain, res)
+		}
+	})
+}
+
+func TestNewCardanoChainInfo(t *testing.T) {
+	t.Run("fails when a tx provider cannot be created", func(t *testing.T) {
+		info, err := NewCardanoChainInfo(
+			context.Background(), &cCore.CardanoChainConfig{}, &cCore.ProtocolParamsDBMock{}, hclog.NewNullLogger())
+
+		require.Error(t, err)
+		require.Nil(t, info)
+	})
+}

--- a/oracle_common/core/interfaces.go
+++ b/oracle_common/core/interfaces.go
@@ -90,3 +90,8 @@ type BlockSubmitterDB interface {
 	GetBlocksSubmitterInfo(chainID string) (BlocksSubmitterInfo, error)
 	SetBlocksSubmitterInfo(chainID string, info BlocksSubmitterInfo) error
 }
+
+type ProtocolParamsDB interface {
+	SaveProtocolParams(chainID string, protocolParams []byte, expiresAt time.Time) error
+	GetProtocolParams(chainID string) ([]byte, time.Time, error)
+}

--- a/oracle_common/core/test_mocks.go
+++ b/oracle_common/core/test_mocks.go
@@ -1,6 +1,10 @@
 package core
 
-import "github.com/stretchr/testify/mock"
+import (
+	"time"
+
+	"github.com/stretchr/testify/mock"
+)
 
 type TxsProcessorMock struct {
 	mock.Mock
@@ -21,3 +25,33 @@ func (m *ExpectedTxsFetcherMock) Start() {
 }
 
 var _ ExpectedTxsFetcher = (*ExpectedTxsFetcherMock)(nil)
+
+type ProtocolParamsDBMock struct {
+	Params    []byte
+	ExpiresAt time.Time
+	SaveErr   error
+	GetErr    error
+}
+
+var _ ProtocolParamsDB = (*ProtocolParamsDBMock)(nil)
+
+func (m *ProtocolParamsDBMock) SaveProtocolParams(
+	chainID string, protocolParams []byte, expiresAt time.Time,
+) error {
+	if m.SaveErr != nil {
+		return m.SaveErr
+	}
+
+	m.Params = protocolParams
+	m.ExpiresAt = expiresAt
+
+	return nil
+}
+
+func (m *ProtocolParamsDBMock) GetProtocolParams(chainID string) ([]byte, time.Time, error) {
+	if m.GetErr != nil {
+		return nil, time.Time{}, m.GetErr
+	}
+
+	return m.Params, m.ExpiresAt, nil
+}

--- a/oracle_eth/processor/tx_processors/success/bridging_requested_processor_skyline.go
+++ b/oracle_eth/processor/tx_processors/success/bridging_requested_processor_skyline.go
@@ -461,7 +461,9 @@ func (p *BridgingRequestedProcessorSkylineImpl) calculateMinUtxo(
 		return 0, fmt.Errorf("chain info not found for chainID: %s", config.ChainID)
 	}
 
-	builder.SetProtocolParameters(chainInfo.ProtocolParams)
+	protocolParams := chainInfo.GetProtocolParams()
+
+	builder.SetProtocolParameters(protocolParams)
 
 	tokenAmounts := make([]cardanowallet.TokenAmount, 0, len(nativeTokensSum))
 

--- a/oracle_eth/processor/tx_processors/success/bridging_requested_processor_skyline_test.go
+++ b/oracle_eth/processor/tx_processors/success/bridging_requested_processor_skyline_test.go
@@ -1,10 +1,12 @@
 package successtxprocessors
 
 import (
+	"context"
 	"encoding/hex"
 	"fmt"
 	"math/big"
 	"testing"
+	"time"
 
 	brAddrManager "github.com/Ethernal-Tech/apex-bridge/bridging_addresses_manager"
 	cardanotx "github.com/Ethernal-Tech/apex-bridge/cardano"
@@ -174,9 +176,12 @@ func TestBridgingRequestedProcessorSkyline(t *testing.T) {
 		chainInfos := make(map[string]*oChain.CardanoChainInfo, len(appConfig.CardanoChains))
 
 		for _, cc := range appConfig.CardanoChains {
-			info := oChain.NewCardanoChainInfo(cc)
+			cc.OgmiosURL = "http://ogmios.mock" // never contacted: params are pre-seeded and fresh
 
-			info.ProtocolParams = protocolParameters
+			db := &oCore.ProtocolParamsDBMock{Params: protocolParameters, ExpiresAt: time.Now().UTC().Add(time.Hour)}
+
+			info, err := oChain.NewCardanoChainInfo(context.Background(), cc, db, hclog.NewNullLogger())
+			require.NoError(t, err)
 
 			chainInfos[cc.ChainID] = info
 		}

--- a/oracle_solana/processor/tx_processors/success/bridging_requested_processor.go
+++ b/oracle_solana/processor/tx_processors/success/bridging_requested_processor.go
@@ -582,7 +582,9 @@ func (p *BridgingRequestedProcessorImpl) calculateMinUtxo(
 		return 0, fmt.Errorf("chain info not found for chainID: %s", config.ChainID)
 	}
 
-	builder.SetProtocolParameters(chainInfo.ProtocolParams)
+	protocolParams := chainInfo.GetProtocolParams()
+
+	builder.SetProtocolParameters(protocolParams)
 
 	tokenAmounts := make([]cardanowallet.TokenAmount, 0, len(nativeTokensSum))
 

--- a/validatorcomponents/core/interfaces.go
+++ b/validatorcomponents/core/interfaces.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"github.com/Ethernal-Tech/apex-bridge/common"
+	oracleCC "github.com/Ethernal-Tech/apex-bridge/oracle_common/core"
 )
 
 type BridgingRequestStateDB interface {
@@ -12,6 +13,7 @@ type BridgingRequestStateDB interface {
 
 type Database interface {
 	BridgingRequestStateDB
+	oracleCC.ProtocolParamsDB
 	Init(filePath string) error
 	Close() error
 }

--- a/validatorcomponents/database_access/bbolt.go
+++ b/validatorcomponents/database_access/bbolt.go
@@ -3,6 +3,7 @@ package databaseaccess
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/Ethernal-Tech/apex-bridge/common"
 	"github.com/Ethernal-Tech/apex-bridge/validatorcomponents/core"
@@ -15,6 +16,7 @@ type BBoltDatabase struct {
 
 var (
 	bridgingRequestStatesBucket = []byte("BridgingRequestStates")
+	protocolParamsBucket        = []byte("ProtocolParams")
 )
 
 var _ core.Database = (*BBoltDatabase)(nil)
@@ -28,7 +30,7 @@ func (bd *BBoltDatabase) Init(filePath string) error {
 	bd.db = db
 
 	return db.Update(func(tx *bbolt.Tx) error {
-		for _, bn := range [][]byte{bridgingRequestStatesBucket} {
+		for _, bn := range [][]byte{bridgingRequestStatesBucket, protocolParamsBucket} {
 			_, err := tx.CreateBucketIfNotExists(bn)
 			if err != nil {
 				return fmt.Errorf("could not bucket: %s, err: %w", string(bn), err)
@@ -81,6 +83,46 @@ func (bd *BBoltDatabase) UpdateBridgingRequestState(state *common.BridgingReques
 
 		return nil
 	})
+}
+
+type protocolParamsRecord struct {
+	ProtocolParams []byte    `json:"protocolParams"`
+	ExpiresAt      time.Time `json:"expiresAt"`
+}
+
+func (bd *BBoltDatabase) SaveProtocolParams(chainID string, protocolParams []byte, expiresAt time.Time) error {
+	return bd.db.Update(func(tx *bbolt.Tx) error {
+		bytes, err := json.Marshal(protocolParamsRecord{
+			ProtocolParams: protocolParams,
+			ExpiresAt:      expiresAt,
+		})
+		if err != nil {
+			return fmt.Errorf("could not marshal protocol params: %w", err)
+		}
+
+		if err := tx.Bucket(protocolParamsBucket).Put([]byte(chainID), bytes); err != nil {
+			return fmt.Errorf("protocol params write error: %w", err)
+		}
+
+		return nil
+	})
+}
+
+func (bd *BBoltDatabase) GetProtocolParams(chainID string) ([]byte, time.Time, error) {
+	var record protocolParamsRecord
+
+	err := bd.db.View(func(tx *bbolt.Tx) error {
+		if data := tx.Bucket(protocolParamsBucket).Get([]byte(chainID)); len(data) > 0 {
+			return json.Unmarshal(data, &record)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, time.Time{}, err
+	}
+
+	return record.ProtocolParams, record.ExpiresAt, nil
 }
 
 // GetBridgingRequestState implements core.Database.

--- a/validatorcomponents/database_access/bbolt_test.go
+++ b/validatorcomponents/database_access/bbolt_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/Ethernal-Tech/apex-bridge/common"
 	"github.com/stretchr/testify/require"
@@ -123,5 +124,40 @@ func TestBoltDatabase(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, state)
 		require.Equal(t, common.BridgingRequestStatusInvalidRequest, state.Status)
+	})
+
+	t.Run("SaveGetProtocolParams", func(t *testing.T) {
+		t.Cleanup(dbCleanup)
+
+		db := &BBoltDatabase{}
+		err := db.Init(filePath)
+		require.NoError(t, err)
+
+		result, expiresAt, err := db.GetProtocolParams(primeChainID)
+		require.NoError(t, err)
+		require.Nil(t, result)
+		require.True(t, expiresAt.IsZero())
+
+		protocolParams := []byte(`{"maxTxSize":16384}`)
+		expiry := time.Now().UTC().Add(time.Hour)
+
+		err = db.SaveProtocolParams(primeChainID, protocolParams, expiry)
+		require.NoError(t, err)
+
+		result, expiresAt, err = db.GetProtocolParams(primeChainID)
+		require.NoError(t, err)
+		require.Equal(t, protocolParams, result)
+		require.True(t, expiry.Equal(expiresAt))
+
+		updatedParams := []byte(`{"maxTxSize":32768}`)
+		updatedExpiry := expiry.Add(time.Hour)
+
+		err = db.SaveProtocolParams(primeChainID, updatedParams, updatedExpiry)
+		require.NoError(t, err)
+
+		result, expiresAt, err = db.GetProtocolParams(primeChainID)
+		require.NoError(t, err)
+		require.Equal(t, updatedParams, result)
+		require.True(t, updatedExpiry.Equal(expiresAt))
 	})
 }

--- a/validatorcomponents/validatorcomponents/validatorcomponents.go
+++ b/validatorcomponents/validatorcomponents/validatorcomponents.go
@@ -195,10 +195,9 @@ func NewValidatorComponents(
 	cardanoChainInfos := make(map[string]*oracleCommonChain.CardanoChainInfo, len(appConfig.CardanoChains))
 
 	for _, cc := range appConfig.CardanoChains {
-		info := oracleCommonChain.NewCardanoChainInfo(cc)
-
-		if err := info.Populate(ctx); err != nil {
-			return nil, err
+		info, err := oracleCommonChain.NewCardanoChainInfo(ctx, cc, db, logger.Named("cardano_chain_info_"+cc.ChainID))
+		if err != nil {
+			return nil, fmt.Errorf("failed to create cardano chain info for chainID: %s, err: %w", cc.ChainID, err)
 		}
 
 		cardanoChainInfos[cc.ChainID] = info


### PR DESCRIPTION
- validatorcomponents now stores protocol params in its db to ensure we always have some version of protocol params
- RetryForever fetching of protocol params only on startup when theres nothing in the db
- protocol params are refetched if stale
- protocol params become stale after 30 mins, but they will still be used if refetch fails

this all should prevent startup failiures if ogmios is unavailable, and also keep the protocol params somewhat fresh even if the process is long running